### PR TITLE
Copy circleci config to gh-pages

### DIFF
--- a/_bin/deploy.sh
+++ b/_bin/deploy.sh
@@ -5,9 +5,16 @@ set -o pipefail
 set -o nounset
 
 GITHUB_REPO=${GITHUB_REPO:-"caciviclab/www.opendisclosure.io"}
+build_dir=_site
+
+# Add a circleci config to avoid testing the gh-pages branch
+#TODO better way to do this?
+mkdir -p ${build_dir}/.circleci
+cp .circleci/config.yml ${build_dir}/.circleci/
+
 
 # Git init
-cd _site
+cd $build_dir
 git --version
 git init
 git config user.name "CA Civic Lab deploy script"


### PR DESCRIPTION
This should prevent CI from building the gh-pages branch.

CI tries to build the gh-pages branch when it should be ignored. It's ignored in
our circleci config which doesn't exist on the gh-pages branch (since it's not
really part of the build). As a work around, copy the circleci config to
gh-pages.