### PR TITLE
Money bar

### DIFF
--- a/_includes/money-bar.html
+++ b/_includes/money-bar.html
@@ -1,6 +1,6 @@
 {% assign color = include.color | default: "blue" %}
-{% assign maximum = include.max | default: 1000 %}
-{% assign width = include.value | divided_by: maximum %}
+{% assign maximum = include.max | default: 100 %}
+{% assign width = include.value | divided_by: maximum | times: 100 %}
 
 <div class="money-bar">
   <div class="money-bar__label">{{ include.label }}</div>

--- a/_includes/money-bar.html
+++ b/_includes/money-bar.html
@@ -1,0 +1,13 @@
+{% assign color = include.color | default: "blue" %}
+{% assign maximum = include.max | default: 1000 %}
+{% assign width = include.value | divided_by: maximum %}
+
+<div class="money-bar">
+  <div class="money-bar__label">{{ include.label }}</div>
+  <div class="money-bar__measure-container">
+    <div class="money-bar__measure money-bar__measure--{{ color }}" style="width: {{ width }}%;">
+      <span class="money-bar__money money-bar__money--inline">{{ include.value | times: 100 | money }}</span>
+    </div>
+    <span class="money-bar__money">{{ include.value | times: 100 | money }}</span>
+  </div>
+</div>

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -51,8 +51,9 @@ layout: default
         <div class="subheading">Money coming in</div>
         <h2 class="candidate__money-heading">Contributions</h2>
         {% for contribution_type in candidate.supporting_money.contributions_by_type %}
-        <div>{{ contribution_type[0] }}</div>
-        <div>{{ contribution_type[1] | times: 100 | money }}</div>
+          {% assign label=contribution_type[0]  %}
+          {% assign value=contribution_type[1]  %}
+          {% include money-bar.html label=label value=value color="green" %}
         {% endfor %}
         {% if candidate.filer_id and candidate.filer_id != "" %}
           <p><a href="{{ site.baseurl }}/committee/{{ candidate.filer_id }}/">See all contributions</a></p>
@@ -64,8 +65,9 @@ layout: default
         <div class="subheading">Money going out</div>
         <h2 class="candidate__money-heading">Expenditures</h2>
         {% for expenditure_type in candidate.supporting_money.expenditures_by_type %}
-        <div>{{ expenditure_type[0] }}</div>
-        <div>{{ expenditure_type[1] | times: 100 | money }}</div>
+          {% assign label=expenditure_type[0]  %}
+          {% assign value=expenditure_type[1]  %}
+          {% include money-bar.html label=label value=value color="red" %}
         {% endfor %}
       </div>
     </section>

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -46,14 +46,16 @@ layout: default
         <h2 class="candidate__expenditures-opposing">Expenditures opposing candidate <span class="money">{{ candidate.opposing_money.opposing_expenditures | times: 100 | money }}</span></h2>
       </div>
     </section>
+    {% assign money_bar_max = candidate.total_contributions | plus: candidate.total_expenditures %}
     <section class="l-section">
       <div class="l-section__content l-section__content--half">
         <div class="subheading">Money coming in</div>
         <h2 class="candidate__money-heading">Contributions</h2>
+        <div class="candidate__money-total money">{{ candidate.total_contributions | times: 100 | money }}</div>
         {% for contribution_type in candidate.supporting_money.contributions_by_type %}
           {% assign label=contribution_type[0]  %}
           {% assign value=contribution_type[1]  %}
-          {% include money-bar.html label=label value=value color="green" %}
+          {% include money-bar.html label=label value=value color="green" max=money_bar_max %}
         {% endfor %}
         {% if candidate.filer_id and candidate.filer_id != "" %}
           <p><a href="{{ site.baseurl }}/committee/{{ candidate.filer_id }}/">See all contributions</a></p>
@@ -62,10 +64,11 @@ layout: default
       <div class="l-section__content l-section__content--half">
         <div class="subheading">Money going out</div>
         <h2 class="candidate__money-heading">Expenditures</h2>
+        <div class="candidate__money-total money">{{ candidate.total_expenditures | times: 100 | money }}</div>
         {% for expenditure_type in candidate.supporting_money.expenditures_by_type %}
           {% assign label=expenditure_type[0]  %}
           {% assign value=expenditure_type[1]  %}
-          {% include money-bar.html label=label value=value color="red" %}
+          {% include money-bar.html label=label value=value color="red" max=money_bar_max %}
         {% endfor %}
       </div>
     </section>

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -47,7 +47,7 @@ layout: default
       </div>
     </section>
     <section class="l-section">
-      <div class="l-section__content">
+      <div class="l-section__content l-section__content--half">
         <div class="subheading">Money coming in</div>
         <h2 class="candidate__money-heading">Contributions</h2>
         {% for contribution_type in candidate.supporting_money.contributions_by_type %}
@@ -59,9 +59,7 @@ layout: default
           <p><a href="{{ site.baseurl }}/committee/{{ candidate.filer_id }}/">See all contributions</a></p>
         {% endif %}
       </div>
-    </section>
-    <section class="l-section">
-      <div class="l-section__content">
+      <div class="l-section__content l-section__content--half">
         <div class="subheading">Money going out</div>
         <h2 class="candidate__money-heading">Expenditures</h2>
         {% for expenditure_type in candidate.supporting_money.expenditures_by_type %}

--- a/_sass/_module.scss
+++ b/_sass/_module.scss
@@ -4,5 +4,7 @@
 @import 'module/footer';
 @import 'module/header';
 @import 'module/icon';
+@import 'module/money';
+@import 'module/money-bar';
 @import 'module/tagline';
 

--- a/_sass/base/_colors.scss
+++ b/_sass/base/_colors.scss
@@ -21,4 +21,4 @@ $brand-color: $color-navy !default;
 $headings-color: $color-grey-2 !default;
 $link-color: $color-navy !default;
 $note-color: $color-grey-3 !default;
-$subheading-color: $color-grey-3 !default;
+$subheading-color: $color-grey-4 !default;

--- a/_sass/layout/_section.scss
+++ b/_sass/layout/_section.scss
@@ -8,10 +8,24 @@
 
 .l-section__content {
   @include grid-column(12);
-  margin-bottom: $spacing-base;
-  margin-top: $spacing-base;
+  padding-bottom: $spacing-base;
+  padding-top: $spacing-base;
 
   @include grid-media($neat-grid--medium) {
     @include grid-column(12);
+  }
+
+  + .l-section__content {
+    @extend %section-border;
+
+    @media screen and (min-width: $grid--medium) {
+      border-top: none !important;
+    }
+  }
+}
+
+.l-section__content--half {
+  @include grid-media($neat-grid--medium) {
+    @include grid-column(6);
   }
 }

--- a/_sass/layout/_section.scss
+++ b/_sass/layout/_section.scss
@@ -19,7 +19,7 @@
     @extend %section-border;
 
     @media screen and (min-width: $grid--medium) {
-      border-top: none !important;
+      border-top: none !important; // scss-lint:disable ImportantRule
     }
   }
 }

--- a/_sass/module/_candidate.scss
+++ b/_sass/module/_candidate.scss
@@ -51,6 +51,14 @@ $candidate-photo-width: 10rem;
   color: $color-navy;
 }
 
+.candidate__money-total.money {
+  @include heading('h2');
+  color: $color-grey-3;
+  line-height: 1;
+  margin-bottom: $spacing-base * 2;
+  text-align: left;
+}
+
 .candidate__expenditures-opposing {
   @include heading('h3');
   color: $subheading-color;

--- a/_sass/module/_candidate.scss
+++ b/_sass/module/_candidate.scss
@@ -26,9 +26,7 @@ $candidate-photo-width: 10rem;
   margin: ($spacing-base * 2) 0;
 
   .money {
-    font-family: $font-family-serif;
     float: right;
-    text-align: right;
   }
 }
 

--- a/_sass/module/_candidate.scss
+++ b/_sass/module/_candidate.scss
@@ -1,22 +1,26 @@
 $candidate-photo-width: 10rem;
 
 .candidate__occupation {
-  @include heading('h4');
+  @include heading('h3');
   color: $subheading-color;
   font-style: italic;
 }
 
 .candidate__info-container {
-  margin: ($spacing-base * 2) 0;
+  @include grid-container;
+  @include grid-collapse;
+  margin-bottom: ($spacing-base * 2);
 }
 
 .candidate__photo {
+  @include grid-column(3);
   border-radius: ($candidate-photo-width / 2);
   vertical-align: top;
   width: $candidate-photo-width;
 }
 
 .candidate__info {
+  @include grid-column(8);
   display: inline-block;
   margin-left: $spacing-base * 2;
 }
@@ -32,14 +36,26 @@ $candidate-photo-width: 10rem;
 
 .candidate__summary--contributions {
   color: $color-evergreen;
+
+  .money {
+    color: $color-evergreen;
+  }
 }
 
 .candidate__summary--expenditures {
   color: $color-cherry-red;
+
+  .money {
+    color: $color-cherry-red;
+  }
 }
 
 .candidate__summary--loans {
   color: $color-navy;
+
+  .money {
+    color: $color-navy;
+  }
 }
 
 .candidate__summary--balance {

--- a/_sass/module/_money-bar.scss
+++ b/_sass/module/_money-bar.scss
@@ -1,0 +1,60 @@
+$measure-height: 2rem;
+$money-label-width: 9rem; // amount of space we reserve for the money label (approx)
+$money-bar-breakpoint: $grid--small; // breakpoint where measure goes from block to inline
+
+.money-bar {
+  font-size: 1.6rem;
+  line-height: 1;
+  margin-bottom: $spacing-base;
+}
+
+.money-bar__label {
+  font-size: $small-font-size;
+  margin-bottom: ($spacing-base / 2);
+}
+
+.money-bar__measure-container {
+  @media screen and (min-width: $grid--small) {
+    // Show inline on larger screens, reserving space for the money label
+    text-align: right;
+    width: calc(100% - #{$money-label-width});
+  }
+}
+
+.money-bar__money {
+  @extend .money;
+  @extend .money--sans;
+  vertical-align: top;
+  line-height: $measure-height;
+
+  @media screen and (min-width: $money-bar-breakpoint) {
+    // Only inline is visible above the breakpoint
+    display: none;
+  }
+}
+
+.money-bar__money--inline {
+  display: none; // Hide below the breakpoint
+
+  @media screen and (min-width: $money-bar-breakpoint) {
+    // Position absolute so the label hangs off of the measure-container
+    display: inline-block;
+    position: absolute;
+    margin-left: $spacing-base;
+  }
+}
+
+.money-bar__measure {
+  background-color: $color-navy;
+  height: $measure-height;
+  min-width: 5px; // Even zero shows something
+  transition: 1.5s cubic-bezier(0,0,.05,1) width;
+}
+
+.money-bar__measure--green {
+  background-color: $color-green;
+}
+
+.money-bar__measure--red {
+  background-color: $color-red;
+}

--- a/_sass/module/_money-bar.scss
+++ b/_sass/module/_money-bar.scss
@@ -48,7 +48,7 @@ $money-bar-breakpoint: $grid--small; // breakpoint where measure goes from block
   background-color: $color-navy;
   height: $measure-height;
   min-width: 1px; // Even zero shows something
-  transition: 1.5s cubic-bezier(0,0,.05,1) width;
+  transition: 1.5s cubic-bezier(0, 0, .05, 1) width;
 }
 
 .money-bar__measure--green {

--- a/_sass/module/_money-bar.scss
+++ b/_sass/module/_money-bar.scss
@@ -47,7 +47,7 @@ $money-bar-breakpoint: $grid--small; // breakpoint where measure goes from block
 .money-bar__measure {
   background-color: $color-navy;
   height: $measure-height;
-  min-width: 5px; // Even zero shows something
+  min-width: 1px; // Even zero shows something
   transition: 1.5s cubic-bezier(0,0,.05,1) width;
 }
 

--- a/_sass/module/_money.scss
+++ b/_sass/module/_money.scss
@@ -1,0 +1,12 @@
+.money {
+  color: $color-grey-3;
+  font-family: $font-family-serif;
+  text-align: right;
+}
+
+.money--sans {
+  //font-size: 1.6rem;
+  font-weight: 500;
+  color: $color-grey-4;
+  font-family: $font-family-sans-serif;
+}

--- a/_sass/module/_money.scss
+++ b/_sass/module/_money.scss
@@ -5,8 +5,7 @@
 }
 
 .money--sans {
-  //font-size: 1.6rem;
-  font-weight: 500;
   color: $color-grey-4;
   font-family: $font-family-sans-serif;
+  font-weight: 500;
 }


### PR DESCRIPTION
Part of #29 

- [x] depends on https://github.com/caciviclab/odca-jekyll/pull/43

Implements the colored money-bar graphic for candidate contributions and expenditures. Uses `total_contributions + total_expenditures` as the maximum so the bars are relative side-by-side as per the usability session feedback.

## Mobile money bar
<img alt="Mobile &quot;block&quot; money bar" src="https://user-images.githubusercontent.com/509703/37018156-32547130-20c8-11e8-8845-67409a401074.png" width="300" >

## Desktop "inline" money bar
![Desktop "inline" money bar](https://user-images.githubusercontent.com/509703/37018168-387eb9bc-20c8-11e8-8da8-4f89863d399f.png)
