### PR TITLE
Styles for committee/contributions page

### DIFF
--- a/_layouts/committee.html
+++ b/_layouts/committee.html
@@ -15,7 +15,7 @@ layout: default
       <p>Sorry, there is no contribution data available for this committee.</p>
     {% else %}
       <table class="contributors">
-        <thead>
+        <thead class="contributors__thead">
           <tr>
             <td class="contributors__name">Name</td>
             <td class="contributors__amount">Amount</td>

--- a/_layouts/committee.html
+++ b/_layouts/committee.html
@@ -14,20 +14,20 @@ layout: default
     {% if contributions == empty %}
       <p>Sorry, there is no contribution data available for this committee.</p>
     {% else %}
-      <table>
+      <table class="contributors">
         <thead>
           <tr>
-            <td>Name</td>
-            <td>Amount</td>
-            <td>Date</td>
+            <td class="contributors__name">Name</td>
+            <td class="contributors__amount">Amount</td>
+            <td class="contributors__date contributors__col--s1">Date</td>
           </tr>
         </thead>
         <tbody>
           {% for contribution in contributions %}
           <tr>
-            <td>{{ contribution.Tran_NamF | escape }} {{ contribution.Tran_NamL | escape }}</td>
-            <td>{{ contribution.Tran_Amt1 | times: 100 | money }}</td>
-            <td>{{ contribution.Tran_Date | date: "%Y-%m-%d" }}</td>
+            <td class="contributors__name">{{ contribution.Tran_NamF | escape }} {{ contribution.Tran_NamL | escape }}</td>
+            <td class="contributors__amount">{{ contribution.Tran_Amt1 | times: 100 | money }}</td>
+            <td class="contributors__date contributors__col--s1">{{ contribution.Tran_Date | date: "%Y-%m-%d" }}</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/_sass/_module.scss
+++ b/_sass/_module.scss
@@ -1,6 +1,7 @@
 @import 'module/ballot-nav';
 @import 'module/border';
 @import 'module/candidate';
+@import 'module/contributors';
 @import 'module/brand';
 @import 'module/button';
 @import 'module/footer';

--- a/_sass/base/_elements.scss
+++ b/_sass/base/_elements.scss
@@ -45,3 +45,11 @@ nav {
     margin: 0;
   }
 }
+
+table {
+  border-collapse: collapse;
+}
+
+tr {
+  border-bottom: 1px $color-grey-5 solid;
+}

--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -5,13 +5,13 @@ $breakpoint--s2: $grid--medium;
 
 .contributors {
   border-top: 3px $color-gold solid;
+}
 
-  thead {
-    font-weight: bold;
+.contributors__thead {
+  font-weight: bold;
 
-    tr {
-      border-bottom: 1px $color-grey-4 solid;
-    }
+  tr {
+    border-bottom: 1px $color-grey-4 solid;
   }
 }
 

--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -1,0 +1,57 @@
+$col-min-width--s1: 10rem;
+$col-min-width--s2: 14rem;
+$breakpoint--s1: $grid--small;
+$breakpoint--s2: $grid--medium;
+
+.contributors {
+  border-top: 3px $color-gold solid;
+
+  thead {
+    font-weight: bold;
+
+    tr {
+      border-bottom: 1px $color-grey-4 solid;
+    }
+  }
+}
+
+.contributors__name {
+  padding: 0 $spacing-base;
+}
+
+.contributors__amount {
+  padding: 0 $spacing-base;
+  text-align: right;
+  vertical-align: top;
+
+  @include media($breakpoint--s1) {
+    min-width: $col-min-width--s1;
+  }
+
+  @include media($breakpoint--s2) {
+    min-width: $col-min-width--s2;
+  }
+}
+
+.contributors__date {
+  padding: 0 $spacing-base;
+  text-align: left;
+  vertical-align: top;
+  white-space: nowrap;
+
+  @include media($breakpoint--s1) {
+    min-width: $col-min-width--s1;
+  }
+
+  @include media($breakpoint--s2) {
+    min-width: $col-min-width--s2;
+  }
+}
+
+.contributors__col--s1 {
+  display: none;
+
+  @include media($breakpoint--s1) {
+    display: table-cell;
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/caciviclab/odca-jekyll/issues/32

On mobile, we hide the date column to save space.
<img alt="mobile" src="https://user-images.githubusercontent.com/509703/37694260-eab63e50-2c82-11e8-9513-5b20640418dd.png" width="300">

Desktop
![screenshot from 2018-03-20 21-08-41](https://user-images.githubusercontent.com/509703/37694263-f9767d4c-2c82-11e8-9ccf-ddbfc073e60d.png)
