### PR TITLE
Add supporting independent expenditures for candidates

### DIFF
--- a/_ballots/oakland/2018-11-06.md
+++ b/_ballots/oakland/2018-11-06.md
@@ -4,6 +4,8 @@ locality: oakland
 election: 2018-11-06
 office_elections:
 - _office_elections/oakland/2018-11-06/mayor.md
+- _office_elections/oakland/2018-11-06/city-council-district-2.md
+- _office_elections/oakland/2018-11-06/city-council-district-6.md
 referendums:
 - _referendums/oakland/2018-11-06/library-parcel-tax.md
 ---

--- a/_candidates/abel-guillen.md
+++ b/_candidates/abel-guillen.md
@@ -1,0 +1,61 @@
+---
+id: 8
+name: Abel Guillen
+photo_url: 'https://www.facebook.com/AbelGuillen/'
+website_url: 'http://www.voteabelguillen.com/'
+twitter_url: abelguillen
+votersedge_url: null
+first_name: Abel
+last_name: Guillen
+ballot_item: 5
+office_election: 5
+bio: null
+committee_name: Abel Guillen for City Council 2018
+is_accepted_expenditure_ceiling: true
+is_incumbent: true
+occupation: 'Incumbent, Councilmember'
+party_affiliation: null
+filer_id: 1395580
+supporting_money:
+  contributions_received: 61546
+  total_contributions: 61546
+  total_expenditures: 22254.42
+  total_loans_received: 0
+  total_supporting_independent: 0
+  contributions_by_type:
+    Committee: 6925
+    Individual: 45600
+    Unitemized: 771
+    Other (includes Businesses): 8250
+  contributions_by_origin:
+    Out of State: 2300
+    Within Oakland: 37350
+    Within California: 21125
+  expenditures_by_type:
+    Contribution: 1550
+    Civic Donations: 2500
+    Office Expenses: 2656.58
+    Fundraising Events: 12422.3
+    'Professional Services (Legal, Accounting)': 2775.34
+    'Information Technology Costs (Internet, E-mail)': 153.32
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: 61546
+total_contributions: 61546
+total_expenditures: 22254.42
+total_loans_received: 0
+contributions_by_type:
+  Committee: 6925
+  Individual: 45600
+  Unitemized: 771
+  Other (includes Businesses): 8250
+expenditures_by_type:
+  Contribution: 1550
+  Civic Donations: 2500
+  Office Expenses: 2656.58
+  Fundraising Events: 12422.3
+  'Professional Services (Legal, Accounting)': 2775.34
+  'Information Technology Costs (Internet, E-mail)': 153.32
+---

--- a/_candidates/annie-campbell-washington.md
+++ b/_candidates/annie-campbell-washington.md
@@ -1,0 +1,57 @@
+---
+id: 46
+name: Annie Campbell Washington
+photo_url: 'https://www.facebook.com/anniecampbellwashington/'
+website_url: 'http://www.annieforoakland.com'
+twitter_url: anniecampbellwashington
+votersedge_url: null
+first_name: Annie
+last_name: Campbell Washington
+ballot_item: 5
+office_election: 5
+bio: null
+committee_name: Annie Campbell Washington for Oakland City Council 2018
+is_accepted_expenditure_ceiling: true
+is_incumbent: true
+occupation: 'Incumbent, Councilmember'
+party_affiliation: null
+filer_id: 1376660
+supporting_money:
+  contributions_received: 27791
+  total_contributions: 27791
+  total_expenditures: 23538.29
+  total_loans_received: 3600
+  total_supporting_independent: 0
+  contributions_by_type:
+    Committee: 7200
+    Individual: 13500
+    Unitemized: 91
+    Other (includes Businesses): 3400
+  contributions_by_origin:
+    Out of State: 800
+    Within Oakland: 12800
+    Within California: 10500
+  expenditures_by_type:
+    Not Stated: 10300
+    Fundraising Events: 1436.9
+    'Professional Services (Legal, Accounting)': 8408.06
+    'Information Technology Costs (Internet, E-mail)': 3131.38
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: 27791
+total_contributions: 27791
+total_expenditures: 23538.29
+total_loans_received: 3600
+contributions_by_type:
+  Committee: 7200
+  Individual: 13500
+  Unitemized: 91
+  Other (includes Businesses): 3400
+expenditures_by_type:
+  Not Stated: 10300
+  Fundraising Events: 1436.9
+  'Professional Services (Legal, Accounting)': 8408.06
+  'Information Technology Costs (Internet, E-mail)': 3131.38
+---

--- a/_candidates/barbara-parker.md
+++ b/_candidates/barbara-parker.md
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13239/candidate/130764?&county=Alameda%20County&election_authority_id=1
 first_name: Barbara
 last_name: Parker
-ballot_item: 9
-office_election: 9
+ballot_item: 1
+office_election: 1
 bio: >-
   Barbara Parker was appointed City Attorney in 2011 after the retirement of
   then-City Attorney John Russo. Prior to becoming City Attorney, Parker served
@@ -36,6 +36,7 @@ supporting_money:
   total_contributions: 67909
   total_expenditures: 35744.47
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Individual: 59850
     Unitemized: 393
@@ -66,8 +67,6 @@ expenditures_by_type:
   Campaign Paraphernalia/Misc.: 820.44
   Candidate Filing/Ballot Fees: 1477
   Campaign Literature and Mailings: 1559.56
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Barbara Parker was appointed City Attorney in 2011 after the retirement of then-City Attorney John Russo. Prior to becoming City Attorney, Parker served for 20 years in the Oakland City Attorney’s Office, including ten years as Chief Assistant City Attorney. Parker graduated from Harvard Law in 1975 and has worked as an attorney in the private sector for two major corporations and two prominent law firms. She has served as the manager of a large public agency and as an attorney at all levels of government—federal, state, and local—including more than five years as an Assistant United States Attorney for the Northern District of California, where she represented the U.S. in federal court litigation. In 2005, the State Bar Board of Governors selected Parker for an appointment to the State Judicial Council. 
 

--- a/_candidates/benjamin-lang.md
+++ b/_candidates/benjamin-lang.md
@@ -1,5 +1,5 @@
 ---
-id: 19
+id: 28
 name: Benjamin Lang
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Ben-Lang.png'
 website_url: 'http://www.benlang.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13217/candidate/130696?&county=Alameda%20County&election_authority_id=1
 first_name: Benjamin
 last_name: Lang
-ballot_item: 6
-office_election: 6
+ballot_item: 14
+office_election: 14
 bio: >-
   Benjamin Lang has served as a both public school teacher and administrator for
   over two decades. Lang has been a resident of Oakland's District 3 for 42
@@ -31,6 +31,7 @@ supporting_money:
   total_contributions: null
   total_expenditures: null
   total_loans_received: null
+  total_supporting_independent: 0
   contributions_by_type: {}
   contributions_by_origin: {}
   expenditures_by_type: {}
@@ -44,8 +45,6 @@ total_expenditures: null
 total_loans_received: null
 contributions_by_type: {}
 expenditures_by_type: {}
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Benjamin Lang has served as a both public school teacher and administrator for over two decades. Lang has been a resident of Oakland's District 3 for 42 years. He holds a Bachelor’s of Arts in Political Science, a Master’s of Arts in Political Theory, and a Master’s of Sciences in Educational Technologies.Lang has elected to not accept any contributions for his campaign.
 

--- a/_candidates/brenda-roberts.md
+++ b/_candidates/brenda-roberts.md
@@ -1,0 +1,38 @@
+---
+id: 20
+name: Brenda Roberts
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Brenda
+last_name: Roberts
+ballot_item: 2
+office_election: 2
+bio: null
+committee_name: Brenda Roberts for Oakland City Auditor 2018
+is_accepted_expenditure_ceiling: true
+is_incumbent: true
+occupation: 'Incumbent, City Auditor'
+party_affiliation: null
+filer_id: null
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/bruce-quan.md
+++ b/_candidates/bruce-quan.md
@@ -39,6 +39,7 @@ supporting_money:
   total_contributions: 75623.14
   total_expenditures: 75910.59
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 350
     Individual: 31551
@@ -79,8 +80,6 @@ expenditures_by_type:
   Campaign Literature and Mailings: 1056.73
   'Professional Services (Legal, Accounting)': 5575
   'Information Technology Costs (Internet, E-mail)': 1997.97
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Bruce Quan is a retired attorney, Quan worked as the Assistant General Counsel for the Redevelopment Agency of the City of San Jose and served as interim City Attorney for the City of Alameda. He also served as general counsel of the Organization of Chinese Americans (OCA), a national civil rights group based in Washington, He co-founded a law firm, Katz, Quan, and Kors. Quan is also an official with Zarsion, real estate developer and investment firm, partner in Brooklyn Basin development project in the Jack London Square area.Quan volunteers with the Chinese Coalition as well as Oakland Community Organizations (OCO) to address issues of housing displacement, youth civic leadership, and criminal justice for minorities.Quan has taught as a visiting Associate Professor at Peking University Law School and as an Adjunct Professor at U.C. Hastings College of Law. Quan earned his undergraduate degree from UC Berkeley and a law degree from the UC Berkeley Law School.
 

--- a/_candidates/cedric-anthony-troupe.md
+++ b/_candidates/cedric-anthony-troupe.md
@@ -1,0 +1,38 @@
+---
+id: 11
+name: Cedric Anthony Troupe
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Cedric
+last_name: Anthony Troupe
+ballot_item: 10
+office_election: 10
+bio: null
+committee_name: No committee registered
+is_accepted_expenditure_ceiling: false
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: null
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/chris-jackson.md
+++ b/_candidates/chris-jackson.md
@@ -1,5 +1,5 @@
 ---
-id: 27
+id: 43
 name: Chris Jackson
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/chris-jackson.png'
 website_url: 'http://www.chrisjacksonforoakland.org/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13219/candidate/130704?&county=Alameda%20County&election_authority_id=1
 first_name: Chris
 last_name: Jackson
-ballot_item: 4
-office_election: 4
+ballot_item: 16
+office_election: 16
 bio: >-
   Chris Jackson is a social worker who works with the formerly incarcerated on
   parole or probation. He is a father of a kindergartener who is going into an
@@ -30,6 +30,7 @@ supporting_money:
   total_contributions: 14562
   total_expenditures: 35235.23
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 5900
     Individual: 5900
@@ -64,8 +65,6 @@ expenditures_by_type:
   Campaign Paraphernalia/Misc.: 1167.25
   Campaign Literature and Mailings: 1054.74
   'Professional Services (Legal, Accounting)': 3020.47
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Chris Jackson is a social worker who works with the formerly incarcerated on parole or probation. He is a father of a kindergartener who is going into an OUSD school. 
 

--- a/_candidates/dan-kalb.md
+++ b/_candidates/dan-kalb.md
@@ -1,5 +1,5 @@
 ---
-id: 8
+id: 12
 name: Dan Kalb
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/dan-kalb2.png'
 website_url: 'https://dankalb.net'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13235/candidate/130756?&county=Alameda%20County&election_authority_id=1
 first_name: Dan
 last_name: Kalb
-ballot_item: 1
-office_election: 1
+ballot_item: 4
+office_election: 4
 bio: >-
   Dan Kalb was elected in 2013 to represent District 1 in Oakland City Council.
   Past roles Kalb has held include policy analyst, environmental, public
@@ -35,6 +35,7 @@ supporting_money:
   total_contributions: 111576.66
   total_expenditures: 147916.91
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 11350
     Individual: 78927
@@ -92,8 +93,6 @@ expenditures_by_type:
   'Information Technology Costs (Internet, E-mail)': 4226.01
   Independent Expenditure Supporting/Opposing Others: 400
   Transfer Between Committees of the Same Candidate/sponsor: 13500
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Dan Kalb was elected in 2013 to represent District 1 in Oakland City Council. Past roles Kalb has held include policy analyst, environmental, public interest, and social justice advocate, policy director, progressive reformer, and community service volunteer. Kalb serves as the City’s official representative on the StopWaste Board of Directors and is on the East Bay Jewish Community Relations Council Board of Directors. He was the California Policy Director with the Union of Concerned Scientists from 2003 to 2012. He received a Bachelor's of Science in Conservation of Natural Resources from UC Berkeley and a Masters of Public Administration from the University of San Francisco. 
 

--- a/_candidates/desley-brooks.md
+++ b/_candidates/desley-brooks.md
@@ -1,0 +1,68 @@
+---
+id: 44
+name: Desley Brooks
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Desley
+last_name: Brooks
+ballot_item: 8
+office_election: 8
+bio: null
+committee_name: Desley Brooks for City Council 2018
+is_accepted_expenditure_ceiling: true
+is_incumbent: true
+occupation: null
+party_affiliation: null
+filer_id: 1236617
+supporting_money:
+  contributions_received: 16800
+  total_contributions: 16800
+  total_expenditures: 22496.14
+  total_loans_received: -2400
+  total_supporting_independent: 0
+  contributions_by_type:
+    Individual: 22000
+    Unitemized: 0
+    Other (includes Businesses): -2100
+  contributions_by_origin:
+    Within Oakland: 5500
+    Within California: 14400
+  expenditures_by_type:
+    Not Stated: 6985.48
+    Contribution: 700
+    Legal Defense: 1000
+    Civic Donations: 1725
+    Office Expenses: 4275.6
+    Fundraising Events: 1893.34
+    Campaign Consultants: 2500
+    Member Communications: 199.19
+    Candidate Filing/Ballot Fees: 250
+    'Candidate Travel, Lodging, and Meals': 1440.61
+    'Postage, Delivery and Messenger Services': 102
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: 16800
+total_contributions: 16800
+total_expenditures: 22496.14
+total_loans_received: -2400
+contributions_by_type:
+  Individual: 22000
+  Unitemized: 0
+  Other (includes Businesses): -2100
+expenditures_by_type:
+  Not Stated: 6985.48
+  Contribution: 700
+  Legal Defense: 1000
+  Civic Donations: 1725
+  Office Expenses: 4275.6
+  Fundraising Events: 1893.34
+  Campaign Consultants: 2500
+  Member Communications: 199.19
+  Candidate Filing/Ballot Fees: 250
+  'Candidate Travel, Lodging, and Meals': 1440.61
+  'Postage, Delivery and Messenger Services': 102
+---

--- a/_candidates/donald-macleay.md
+++ b/_candidates/donald-macleay.md
@@ -1,5 +1,5 @@
 ---
-id: 16
+id: 25
 name: Donald Macleay
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Donald-Macleay1.png'
 website_url: 'http://www.don4ousd.org/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13216/candidate/130694?&county=Alameda%20County&election_authority_id=1
 first_name: Donald
 last_name: Macleay
-ballot_item: 5
-office_election: 5
+ballot_item: 13
+office_election: 13
 bio: >-
   Don Macleay owns and runs East Bay Computer Services, a computer repair
   business in the Temescal district.  While running for office, Macleay is on
@@ -31,6 +31,7 @@ supporting_money:
   total_contributions: 5219.5
   total_expenditures: 7369.87
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Individual: 2630
     Unitemized: 839.5
@@ -79,8 +80,6 @@ expenditures_by_type:
   'Staff/Spouse Travel, Lodging, and Meals': 320.14
   'Professional Services (Legal, Accounting)': 372.42
   'Information Technology Costs (Internet, E-mail)': 100
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Don Macleay owns and runs East Bay Computer Services, a computer repair business in the Temescal district.  While running for office, Macleay is on leave from People United for a Better Life in Oakland, a youth advocacy organization where he serves as a board member. In 2010, Macleay ran for mayor in Oakland. 
 

--- a/_candidates/ebony-edgerson.md
+++ b/_candidates/ebony-edgerson.md
@@ -1,0 +1,38 @@
+---
+id: 34
+name: Ebony Edgerson
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Ebony
+last_name: Edgerson
+ballot_item: 12
+office_election: 12
+bio: null
+committee_name: No committee registered
+is_accepted_expenditure_ceiling: false
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: null
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/francis-matt-hummel.md
+++ b/_candidates/francis-matt-hummel.md
@@ -1,0 +1,62 @@
+---
+id: 5
+name: Francis Matt Hummel
+photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/F-Matt-Hummell.png'
+website_url: 'http://matt4thepeople.nationbuilder.com/'
+twitter_url: null
+votersedge_url: >-
+  http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13234/candidate/130750?&county=Alameda%20County&election_authority_id=1
+first_name: Francis
+last_name: Matt Hummel
+ballot_item: 3
+office_election: 3
+bio: >-
+  Francis Matt Hummel moved to Oakland from Stockton in 1992. He is Chair of the
+  Cannabis Regulatory Commission. 
+
+
+  Source: Candidate Statement
+committee_name: Matt Hummel 4 the People
+is_accepted_expenditure_ceiling: null
+is_incumbent: false
+occupation: 'Chair, Cannabis Regulatory Commission'
+party_affiliation: null
+filer_id: 1389717
+supporting_money:
+  contributions_received: 1750
+  total_contributions: 1750
+  total_expenditures: 5148.26
+  total_loans_received: 0
+  total_supporting_independent: 0
+  contributions_by_type:
+    Individual: 1750
+    Unitemized: 0
+  contributions_by_origin:
+    Within Oakland: 1750
+  expenditures_by_type:
+    Print Ads: 500
+    Campaign Consultants: 1000
+    Campaign Workers' Salaries: 1000
+    Campaign Paraphernalia/Misc.: 1612.37
+    Campaign Literature and Mailings: 300
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: 1750
+total_contributions: 1750
+total_expenditures: 5148.26
+total_loans_received: 0
+contributions_by_type:
+  Individual: 1750
+  Unitemized: 0
+expenditures_by_type:
+  Print Ads: 500
+  Campaign Consultants: 1000
+  Campaign Workers' Salaries: 1000
+  Campaign Paraphernalia/Misc.: 1612.37
+  Campaign Literature and Mailings: 300
+---
+Francis Matt Hummel moved to Oakland from Stockton in 1992. He is Chair of the Cannabis Regulatory Commission. 
+
+Source: Candidate Statement

--- a/_candidates/huber-trenado.md
+++ b/_candidates/huber-trenado.md
@@ -1,5 +1,5 @@
 ---
-id: 25
+id: 41
 name: Huber Trenado
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Huber-Trenado.png'
 website_url: 'http://www.votetrenadoousd.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13218/candidate/130702?&county=Alameda%20County&election_authority_id=1
 first_name: Huber
 last_name: Trenado
-ballot_item: 8
-office_election: 8
+ballot_item: 15
+office_election: 15
 bio: >-
   Huber Trenado is a teacher, community leader, and Oakland native. Trenado has
   helped establish an Aim High program site to increase the quality of academic
@@ -30,6 +30,7 @@ supporting_money:
   total_contributions: 21685.48
   total_expenditures: 23562.66
   total_loans_received: 0
+  total_supporting_independent: 101339
   contributions_by_type:
     Individual: 16163.31
     Unitemized: 1798
@@ -82,8 +83,6 @@ expenditures_by_type:
   Campaign Literature and Mailings: 10825.06
   'Professional Services (Legal, Accounting)': 2500
   'Information Technology Costs (Internet, E-mail)': 833.57
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Huber Trenado is a teacher, community leader, and Oakland native. Trenado has helped establish an Aim High program site to increase the quality of academic programs offered to students during the summer and implement common core standards in Oakland United School District classrooms. Trenado graduated from UC Berkeley. 
 

--- a/_candidates/james-harris.md
+++ b/_candidates/james-harris.md
@@ -1,5 +1,5 @@
 ---
-id: 26
+id: 42
 name: James Harris
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/james-harris.png'
 website_url: 'http://harrisforeastoakland.com/about-james/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13219/candidate/130703?&county=Alameda%20County&election_authority_id=1
 first_name: James
 last_name: Harris
-ballot_item: 4
-office_election: 4
+ballot_item: 16
+office_election: 16
 bio: >-
   James Harris is the current Board of Education President, a business owner,
   parent, former teacher, and East Oakland native. Harris serves on the Aim High
@@ -32,6 +32,7 @@ supporting_money:
   total_contributions: 27586
   total_expenditures: 26950.43
   total_loans_received: 0
+  total_supporting_independent: 159034
   contributions_by_type:
     Committee: 5700
     Individual: 21536
@@ -83,8 +84,6 @@ expenditures_by_type:
   Campaign Paraphernalia/Misc.: 2443.7
   Candidate Filing/Ballot Fees: 250
   'Professional Services (Legal, Accounting)': 4542.81
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 James Harris is the current Board of Education President, a business owner, parent, former teacher, and East Oakland native. Harris serves on the Aim High East Bay Leadership Council. He is a founding board member of Great Oakland Public Schools and a current board member at Youth Uprising. Harris’ career in education began at 16 as a teaching assistant at the Aim High Summer Program, which prepares children from low-income communities for success in high school and life. 
 

--- a/_candidates/jane-kim.md
+++ b/_candidates/jane-kim.md
@@ -1,0 +1,58 @@
+---
+id: 49
+name: Jane Kim
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Jane
+last_name: Kim
+ballot_item: 10
+office_election: 10
+bio: null
+committee_name: Jane Kim for Mayor 2018
+is_accepted_expenditure_ceiling: null
+is_incumbent: null
+occupation: null
+party_affiliation: null
+filer_id: 1400832
+supporting_money:
+  contributions_received: 51080.3
+  total_contributions: 51080.3
+  total_expenditures: 3331.03
+  total_loans_received: 0
+  total_supporting_independent: 0
+  contributions_by_type:
+    Committee: 100
+    Individual: 47051
+    Unitemized: 3829.3
+    Other (includes Businesses): 100
+  contributions_by_origin:
+    Out of State: 1450
+    Within Oakland: 850
+    Within California: 44951
+  expenditures_by_type:
+    Not Stated: 500
+    Office Expenses: 1777.26
+  supporting_by_type:
+    Civic Donations: 387.38
+    Campaign Consultants: 8153
+    Meetings and Appearances: 756
+    'Professional Services (Legal, Accounting)': 2619.62
+    'Information Technology Costs (Internet, E-mail)': 7345
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: 51080.3
+total_contributions: 51080.3
+total_expenditures: 3331.03
+total_loans_received: 0
+contributions_by_type:
+  Committee: 100
+  Individual: 47051
+  Unitemized: 3829.3
+  Other (includes Businesses): 100
+expenditures_by_type:
+  Not Stated: 500
+  Office Expenses: 1777.26
+---

--- a/_candidates/jeff-sheehy.md
+++ b/_candidates/jeff-sheehy.md
@@ -1,39 +1,71 @@
 ---
-id: 28
+id: 47
 name: Jeff Sheehy
 photo_url: null
-website_url: "http://jeffsheehy.org/"
+website_url: null
 twitter_url: null
 votersedge_url: null
 first_name: Jeff
 last_name: Sheehy
-ballot_item: 16
-office_election: 16
+ballot_item: 17
+office_election: 17
 bio: null
 committee_name: JEFF SHEEHY FOR SUPERVISOR JUNE 2018
 is_accepted_expenditure_ceiling: null
 is_incumbent: null
 occupation: null
 party_affiliation: null
-filer_id: null
+filer_id: 1395306
 supporting_money:
-  contributions_received: null
-  total_contributions: null
-  total_expenditures: null
-  total_loans_received: null
-  contributions_by_type: {}
-  contributions_by_origin: {}
-  expenditures_by_type: {}
+  contributions_received: 182435.91
+  total_contributions: 182435.91
+  total_expenditures: 116942.62
+  total_loans_received: 0
+  total_supporting_independent: 0
+  contributions_by_type:
+    Committee: 6917
+    Individual: 171315.17
+    Unitemized: 1703.74
+    Other (includes Businesses): 2500
+  contributions_by_origin:
+    Out of State: 200
+    Within Oakland: 3100
+    Within California: 177432.17
+  expenditures_by_type:
+    Print Ads: 5956.2
+    Not Stated: 5609.14
+    Contribution: 1200
+    Office Expenses: 7470.07
+    Campaign Consultants: 41522.73
+    Campaign Workers' Salaries: 6400
+    Polling and Survey Research: 14300
+    Campaign Paraphernalia/Misc.: 6656.06
+    Campaign Literature and Mailings: 4151.99
+    'Professional Services (Legal, Accounting)': 13930.61
+    'Information Technology Costs (Internet, E-mail)': 2350
   supporting_by_type: {}
 opposing_money:
   opposing_expenditures: null
   opposing_by_type: {}
-contributions_received: null
-total_contributions: null
-total_expenditures: null
-total_loans_received: null
-contributions_by_type: {}
-expenditures_by_type: {}
-ballots:
-- _ballots/san-francisco/2018-11-06.md
+contributions_received: 182435.91
+total_contributions: 182435.91
+total_expenditures: 116942.62
+total_loans_received: 0
+contributions_by_type:
+  Committee: 6917
+  Individual: 171315.17
+  Unitemized: 1703.74
+  Other (includes Businesses): 2500
+expenditures_by_type:
+  Print Ads: 5956.2
+  Not Stated: 5609.14
+  Contribution: 1200
+  Office Expenses: 7470.07
+  Campaign Consultants: 41522.73
+  Campaign Workers' Salaries: 6400
+  Polling and Survey Research: 14300
+  Campaign Paraphernalia/Misc.: 6656.06
+  Campaign Literature and Mailings: 4151.99
+  'Professional Services (Legal, Accounting)': 13930.61
+  'Information Technology Costs (Internet, E-mail)': 2350
 ---

--- a/_candidates/jesse-a-j-smith.md
+++ b/_candidates/jesse-a-j-smith.md
@@ -1,0 +1,38 @@
+---
+id: 10
+name: Jesse A.J. Smith
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Jesse
+last_name: A.J. Smith
+ballot_item: 10
+office_election: 10
+bio: null
+committee_name: No committee registered
+is_accepted_expenditure_ceiling: false
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: null
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/jody-london.md
+++ b/_candidates/jody-london.md
@@ -1,5 +1,5 @@
 ---
-id: 17
+id: 26
 name: Jody London
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Jody-London2.jpg.png'
 website_url: 'http://www.votejody.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13216/candidate/130693?&county=Alameda%20County&election_authority_id=1
 first_name: Jody
 last_name: London
-ballot_item: 5
-office_election: 5
+ballot_item: 13
+office_election: 13
 bio: >-
   Jody London was elected to the Oakland School Board in 2009 to represent
   District 1. As a parent of two students who have attended Oakland Unified,
@@ -33,6 +33,7 @@ supporting_money:
   total_contributions: 22344
   total_expenditures: 23891
   total_loans_received: 0
+  total_supporting_independent: 3930
   contributions_by_type:
     Committee: 500
     Individual: 15485
@@ -74,8 +75,6 @@ expenditures_by_type:
   Campaign Paraphernalia/Misc.: 3755.99
   Candidate Filing/Ballot Fees: 300
   Campaign Literature and Mailings: 15150
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Jody London was elected to the Oakland School Board in 2009 to represent District 1. As a parent of two students who have attended Oakland Unified, London began working with the OUSD as a parent volunteer. Before being elected to the board, she chaired the Measure B bond campaign in 2006, served on the bond oversight committee, and led her neighborhood school community in designing and building a new school. London holds a Bachelor of Arts in English, with high honors, from UC Berkeley, and a Master's degreee in Public Administration from Columbia University. 
 

--- a/_candidates/jumoke-hinton-hodge.md
+++ b/_candidates/jumoke-hinton-hodge.md
@@ -1,5 +1,5 @@
 ---
-id: 18
+id: 27
 name: Jumoke Hinton Hodge
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Hinton-Hodge.png'
 website_url: 'https://hintonhodge.nationbuilder.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13217/candidate/130695?&county=Alameda%20County&election_authority_id=1
 first_name: Jumoke
 last_name: Hinton Hodge
-ballot_item: 6
-office_election: 6
+ballot_item: 14
+office_election: 14
 bio: >-
   Jumoke Hinton-Hodge is running for re-election as District 3 representative
   for the Oakland Unified School Board of Education. Hinton-Hodge is the
@@ -31,6 +31,7 @@ supporting_money:
   total_contributions: 25041.85
   total_expenditures: 25486.04
   total_loans_received: 7125
+  total_supporting_independent: 117796
   contributions_by_type:
     Committee: 1500
     Individual: 15788
@@ -77,8 +78,6 @@ expenditures_by_type:
   Campaign Literature and Mailings: 5458.08
   'Professional Services (Legal, Accounting)': 1200
   'Information Technology Costs (Internet, E-mail)': 2056.29
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Jumoke Hinton-Hodge is running for re-election as District 3 representative for the Oakland Unified School Board of Education. Hinton-Hodge is the co-founder of the Parent Leadership and Engagement Academy Initiative (PLEA), a community-building project dedicated to the education and support of West Oakland parents and families. She received a Bachelor degree in Black Studies and English from Oberlin College. 
 

--- a/_candidates/ken-houston.md
+++ b/_candidates/ken-houston.md
@@ -1,17 +1,17 @@
 ---
-id: 41
+id: 33
 name: Ken Houston
 photo_url: null
 website_url: null
-twitter_url: '@KHouston4Mayor'
+twitter_url: KHouston4Mayor
 votersedge_url: null
 first_name: Ken
 last_name: Houston
-ballot_item: 9
-office_election: 9
+ballot_item: 10
+office_election: 10
 bio: null
-committee_name: null
-is_accepted_expenditure_ceiling: null
+committee_name: No committee registered
+is_accepted_expenditure_ceiling: false
 is_incumbent: false
 occupation: null
 party_affiliation: null
@@ -21,6 +21,7 @@ supporting_money:
   total_contributions: null
   total_expenditures: null
   total_loans_received: null
+  total_supporting_independent: 0
   contributions_by_type: {}
   contributions_by_origin: {}
   expenditures_by_type: {}
@@ -34,6 +35,4 @@ total_expenditures: null
 total_loans_received: null
 contributions_by_type: {}
 expenditures_by_type: {}
-ballots:
-- _ballots/san-francisco/2018-11-06.md
 ---

--- a/_candidates/kevin-corbett.md
+++ b/_candidates/kevin-corbett.md
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13235/candidate/130755?&county=Alameda%20County&election_authority_id=1
 first_name: Kevin
 last_name: Corbett
-ballot_item: 1
-office_election: 1
+ballot_item: 4
+office_election: 4
 bio: >-
   Kevin Corbett is a practicing attorney and has run his own law practice for
   the past 30 years. Corbett attended Bishop O'Dowd High School in Oakland and
@@ -30,6 +30,7 @@ supporting_money:
   total_contributions: 42542
   total_expenditures: 77186.88
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 350
     Individual: 36100
@@ -66,8 +67,6 @@ expenditures_by_type:
   Campaign Literature and Mailings: 7535.18
   'Postage, Delivery and Messenger Services': 12149.88
   'Professional Services (Legal, Accounting)': 5380.73
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Kevin Corbett is a practicing attorney and has run his own law practice for the past 30 years. Corbett attended Bishop O'Dowd High School in Oakland and earned his Bachelor’s Degree and Juris Doctorate from Santa Clara University. He has worked as a Business Law Professor at Vista Community College and Holy Names University. 
 

--- a/_candidates/kharyshi-wiginton.md
+++ b/_candidates/kharyshi-wiginton.md
@@ -1,5 +1,5 @@
 ---
-id: 20
+id: 29
 name: Kharyshi Wiginton
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Kharyshi-Wiginton.png'
 website_url: 'http://www.mskfordistrict3sb.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13217/candidate/130698?&county=Alameda%20County&election_authority_id=1
 first_name: Kharyshi
 last_name: Wiginton
-ballot_item: 6
-office_election: 6
+ballot_item: 14
+office_election: 14
 bio: >-
   Kharyshi Wiginton is the Youth Leadership Coordinator at McClymonds Youth and
   Family Center has spent a decade doing education-related work in Oakland and
@@ -32,6 +32,7 @@ supporting_money:
   total_contributions: 5798
   total_expenditures: 4886.23
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Individual: 2590
     Unitemized: 1093
@@ -72,8 +73,6 @@ expenditures_by_type:
   Campaign Literature and Mailings: 1187.01
   'Professional Services (Legal, Accounting)': 500
   'Information Technology Costs (Internet, E-mail)': 381.89
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Kharyshi Wiginton is the Youth Leadership Coordinator at McClymonds Youth and Family Center has spent a decade doing education-related work in Oakland and currently holds a position at McClymonds High School. Wiginton graduated from the California Institute of Integral Studies in 2009. 
 

--- a/_candidates/kristina-molina.md
+++ b/_candidates/kristina-molina.md
@@ -1,5 +1,5 @@
 ---
-id: 40
+id: 32
 name: Kristina Molina
 photo_url: null
 website_url: null
@@ -7,10 +7,10 @@ twitter_url: null
 votersedge_url: null
 first_name: Kristina
 last_name: Molina
-ballot_item: 9
-office_election: 9
+ballot_item: 10
+office_election: 10
 bio: null
-committee_name: null
+committee_name: No committee registered
 is_accepted_expenditure_ceiling: true
 is_incumbent: false
 occupation: null
@@ -21,6 +21,7 @@ supporting_money:
   total_contributions: null
   total_expenditures: null
   total_loans_received: null
+  total_supporting_independent: 0
   contributions_by_type: {}
   contributions_by_origin: {}
   expenditures_by_type: {}
@@ -34,6 +35,4 @@ total_expenditures: null
 total_loans_received: null
 contributions_by_type: {}
 expenditures_by_type: {}
-ballots:
-- _ballots/oakland/2018-11-06.md
 ---

--- a/_candidates/larry-reid.md
+++ b/_candidates/larry-reid.md
@@ -1,5 +1,5 @@
 ---
-id: 15
+id: 24
 name: Larry Reid
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/larry-reid.png'
 website_url: 'https://www.facebook.com/LarryReid4District7/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13238/candidate/130763?&county=Alameda%20County&election_authority_id=1
 first_name: Larry
 last_name: Reid
-ballot_item: 7
-office_election: 7
+ballot_item: 9
+office_election: 9
 bio: >-
   Larry Reid has been a Councilmember for District 7 since 1997. Reid is a
   member of the Public Works and Rules and Legislation Committees for the City
@@ -33,6 +33,7 @@ supporting_money:
   total_contributions: 73352.51
   total_expenditures: 76660.71
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 8330
     Individual: 48550
@@ -81,8 +82,6 @@ expenditures_by_type:
   'Staff/Spouse Travel, Lodging, and Meals': 202.76
   'Professional Services (Legal, Accounting)': 10248.12
   'Information Technology Costs (Internet, E-mail)': 2575.69
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Larry Reid has been a Councilmember for District 7 since 1997. Reid is a member of the Public Works and Rules and Legislation Committees for the City of Oakland and is Chairman of the Community and Economic Development Committee. Reid served as Chief of Staff for former Oakland City Councilmember Aleta Cannon and former Mayor and Assemblymember Elihu Harris. He was born and raised in Cincinnati, Ohio and attended the University of Cincinnati. 
 

--- a/_candidates/libby-schaaf.md
+++ b/_candidates/libby-schaaf.md
@@ -1,23 +1,27 @@
 ---
-id: 39
+id: 9
 name: Libby Schaaf
-photo_url: ""
-website_url: "https://libbyformayor.wordpress.com/"
-twitter_url: "https://twitter.com/LibbySchaaf"
-votersedge_url: ""
+photo_url: 'https://www.facebook.com/MayorLibbySchaaf/'
+website_url: 'https://libbyformayor.wordpress.com/'
+twitter_url: LibbySchaaf
+votersedge_url: null
 first_name: Libby
 last_name: Schaaf
+ballot_item: 10
+office_election: 10
+bio: null
 committee_name: Libby Schaaf for Mayor 2018
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
 occupation: 'Incumbent, Mayor'
 party_affiliation: null
-filer_id: null
+filer_id: 1395968
 supporting_money:
   contributions_received: 262193.66
   total_contributions: 262193.66
   total_expenditures: 36153.65
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 2250
     Individual: 235919.66
@@ -54,6 +58,4 @@ expenditures_by_type:
   Returned Contributions: 2700
   'Professional Services (Legal, Accounting)': 13994
   'Information Technology Costs (Internet, E-mail)': 975
-ballots:
-- _ballots/oakland/2018-11-06.md
 ---

--- a/_candidates/loren-taylor.md
+++ b/_candidates/loren-taylor.md
@@ -1,0 +1,38 @@
+---
+id: 19
+name: Loren Taylor
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Loren
+last_name: Taylor
+ballot_item: 8
+office_election: 8
+bio: null
+committee_name: Loren Taylor for Oakland City Council 2018
+is_accepted_expenditure_ceiling: true
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: 1401499
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/lucky-narain.md
+++ b/_candidates/lucky-narain.md
@@ -1,5 +1,5 @@
 ---
-id: 21
+id: 37
 name: Lucky Narain
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Lucky-Narain.png'
 website_url: null
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13217/candidate/130697?&county=Alameda%20County&election_authority_id=1
 first_name: Lucky
 last_name: Narain
-ballot_item: 6
-office_election: 6
+ballot_item: 14
+office_election: 14
 bio: >-
   Lucky Narain is currently an Associate Regional Public Affairs Director for
   the United States Department of Agriculture (USDA). He is a Oakland resident
@@ -33,6 +33,7 @@ supporting_money:
   total_contributions: null
   total_expenditures: null
   total_loans_received: null
+  total_supporting_independent: 0
   contributions_by_type: {}
   contributions_by_origin: {}
   expenditures_by_type: {}
@@ -46,8 +47,6 @@ total_expenditures: null
 total_loans_received: null
 contributions_by_type: {}
 expenditures_by_type: {}
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Lucky Narain is currently an Associate Regional Public Affairs Director for the United States Department of Agriculture (USDA). He is a Oakland resident and father. For almost three years, Narain taught middle school in the Dominican Republic with the Peace Corps as a volunteer in 2001. He holds a Master’s Degree in Public Policy from Carnegie Mellon University and a law degree from Fordham Law School. Narain has served as a lawyer in the U.S. Army Reserve since 2010. 
 

--- a/_candidates/lynette-gibson-mcelhaney.md
+++ b/_candidates/lynette-gibson-mcelhaney.md
@@ -1,5 +1,5 @@
 ---
-id: 9
+id: 13
 name: Lynette Gibson McElhaney
 photo_url: >-
   https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Lynette-Gibson-McElhaney.png
@@ -9,8 +9,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13236/candidate/130757?&county=Alameda%20County&election_authority_id=1
 first_name: Lynette
 last_name: Gibson McElhaney
-ballot_item: 2
-office_election: 2
+ballot_item: 6
+office_election: 6
 bio: >-
   Lynnette McElhaney currently serves as an Oakland City Council member
   representing District 3 and has advocated for the betterment of Oakland in
@@ -30,6 +30,7 @@ supporting_money:
   total_contributions: 126756.69
   total_expenditures: 134875.99
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 15850
     Individual: 80872.77
@@ -82,8 +83,6 @@ expenditures_by_type:
   'Candidate Travel, Lodging, and Meals': 91.39
   'Professional Services (Legal, Accounting)': 21335.45
   'Information Technology Costs (Internet, E-mail)': 4228.5
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Lynnette McElhaney currently serves as an Oakland City Council member representing District 3 and has advocated for the betterment of Oakland in terms of enhancing jobs, public safety, education and the economy. She earned a degree from UC Berkeley and moved to West Oakland after graduating college. 
 

--- a/_candidates/marchon-tatmon.md
+++ b/_candidates/marchon-tatmon.md
@@ -1,0 +1,38 @@
+---
+id: 21
+name: Marchon Tatmon
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Marchon
+last_name: Tatmon
+ballot_item: 10
+office_election: 10
+bio: null
+committee_name: Marchon Tatmon Mayor for Oakland 2018
+is_accepted_expenditure_ceiling: true
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: 1403436
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/marcie-hodge.md
+++ b/_candidates/marcie-hodge.md
@@ -1,5 +1,5 @@
 ---
-id: 13
+id: 17
 name: Marcie Hodge
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Marcie-Hodge.png'
 website_url: 'http://hodge4oaklandcitycouncil.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13238/candidate/130761?&county=Alameda%20County&election_authority_id=1
 first_name: Marcie
 last_name: Hodge
-ballot_item: 7
-office_election: 7
+ballot_item: 9
+office_election: 9
 bio: >-
   Marcie Hodge is the Executive Director for SJBH, Inc. (St. John Boys Home,
   Inc.(?)), a non-profit residential program for developmentally disabled kids
@@ -32,6 +32,7 @@ supporting_money:
   total_contributions: 20349
   total_expenditures: 16624.17
   total_loans_received: 19857
+  total_supporting_independent: 0
   contributions_by_type:
     Unitemized: 442
     Self Funding: 50
@@ -56,8 +57,6 @@ expenditures_by_type:
   Not Stated: 435.74
   Campaign Paraphernalia/Misc.: 13557.03
   'Professional Services (Legal, Accounting)': 850
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Marcie Hodge is the Executive Director for SJBH, Inc. (St. John Boys Home, Inc.(?)), a non-profit residential program for developmentally disabled kids based in Oakland for the past eight years. Hodge served two terms as a trustee on the Peralta Community College Board from 2004–12, Oakland Budget Committee, and other education-focused committees. Hodge holds two master’s degrees in Counseling Psychology and Organizational Psychology from Alliant International University-Fresno. Hodge ran for mayor of Oakland in 2010. 
 

--- a/_candidates/maria-rodriguez.md
+++ b/_candidates/maria-rodriguez.md
@@ -1,0 +1,38 @@
+---
+id: 35
+name: Maria Rodriguez
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Maria
+last_name: Rodriguez
+ballot_item: 8
+office_election: 8
+bio: null
+committee_name: No committee registered
+is_accepted_expenditure_ceiling: true
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: null
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/mark-leno.md
+++ b/_candidates/mark-leno.md
@@ -1,39 +1,65 @@
 ---
-id: 31
+id: 50
 name: Mark Leno
 photo_url: null
-website_url: "http://www.markleno.com/"
+website_url: null
 twitter_url: null
 votersedge_url: null
 first_name: Mark
 last_name: Leno
-ballot_item: 9
-office_election: 9
+ballot_item: 10
+office_election: 10
 bio: null
 committee_name: Mark Leno for Mayor 2018
 is_accepted_expenditure_ceiling: null
 is_incumbent: null
 occupation: null
 party_affiliation: null
-filer_id: null
+filer_id: 1396338
 supporting_money:
-  contributions_received: null
-  total_contributions: null
-  total_expenditures: null
-  total_loans_received: null
-  contributions_by_type: {}
-  contributions_by_origin: {}
-  expenditures_by_type: {}
+  contributions_received: 418146.96
+  total_contributions: 418146.96
+  total_expenditures: 93379.24
+  total_loans_received: 0
+  total_supporting_independent: 0
+  contributions_by_type:
+    Committee: 5500
+    Individual: 405430.96
+    Unitemized: 4966
+    Other (includes Businesses): 2250
+  contributions_by_origin:
+    Out of State: 18419.98
+    Within Oakland: 8200
+    Within California: 386560.98
+  expenditures_by_type:
+    Not Stated: 778.22
+    Office Expenses: 34026.8
+    Returned Contributions: 2000
+    Campaign Workers' Salaries: 32180.25
+    Campaign Paraphernalia/Misc.: 364
+    'Postage, Delivery and Messenger Services': 15.14
+    'Professional Services (Legal, Accounting)': 2000
+    'Information Technology Costs (Internet, E-mail)': 8000
   supporting_by_type: {}
 opposing_money:
   opposing_expenditures: null
   opposing_by_type: {}
-contributions_received: null
-total_contributions: null
-total_expenditures: null
-total_loans_received: null
-contributions_by_type: {}
-expenditures_by_type: {}
-ballots:
-- _ballots/san-francisco/2018-06-05.md
+contributions_received: 418146.96
+total_contributions: 418146.96
+total_expenditures: 93379.24
+total_loans_received: 0
+contributions_by_type:
+  Committee: 5500
+  Individual: 405430.96
+  Unitemized: 4966
+  Other (includes Businesses): 2250
+expenditures_by_type:
+  Not Stated: 778.22
+  Office Expenses: 34026.8
+  Returned Contributions: 2000
+  Campaign Workers' Salaries: 32180.25
+  Campaign Paraphernalia/Misc.: 364
+  'Postage, Delivery and Messenger Services': 15.14
+  'Professional Services (Legal, Accounting)': 2000
+  'Information Technology Costs (Internet, E-mail)': 8000
 ---

--- a/_candidates/michael-hassid.md
+++ b/_candidates/michael-hassid.md
@@ -1,5 +1,5 @@
 ---
-id: 22
+id: 38
 name: Michael Hassid
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Michael-Hassid.png'
 website_url: 'http://www.mikehassidforschoolboard.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13218/candidate/130699?&county=Alameda%20County&election_authority_id=1
 first_name: Michael
 last_name: Hassid
-ballot_item: 8
-office_election: 8
+ballot_item: 15
+office_election: 15
 bio: >-
   Mike Hassid currently serves as Vice President of Finance and Operations at
   Exponent Partner Partners, a B-Corp and California Benefit Corporation
@@ -42,6 +42,7 @@ supporting_money:
   total_contributions: 8546
   total_expenditures: 8554.69
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Individual: 6950
     Unitemized: 896
@@ -72,8 +73,6 @@ expenditures_by_type:
   Office Expenses: 506.71
   Campaign Consultants: 2500
   'Information Technology Costs (Internet, E-mail)': 265
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Mike Hassid currently serves as Vice President of Finance and Operations at Exponent Partner Partners, a B-Corp and California Benefit Corporation providing strategic technology consulting to nonprofit organizations. Hassid also currently serves on the board of the Community School for Creative Education (CSCE) public school, where his son is a student and his daughter a future student. In the past, Hassid has served as Chief Financial Officer at both StudentsFirst, a national public education advocacy organization, and EnCorps STEM Teachers Program, a nonprofit that recruits professionals in science, technology, engineering and mathematics to become teachers in California public schools. Hassid has also served as Controller at both NewSchools Ventures Fund, a philanthropic firm that funds and supports education entrepreneurs, and at Common Sense Media, a national nonprofit focused on media literacy. Hassid has a Masters of Business Administration from the Masagung Graduate School of Management at The University of San Francisco and a Bachelor of Arts in Philosophy from University of California, Berkeley. He is a Bay Area native and currently lives in the Jingletown neighborhood of Oakland with my wife and two young children. 
 

--- a/_candidates/michael-hutchinson.md
+++ b/_candidates/michael-hutchinson.md
@@ -1,5 +1,5 @@
 ---
-id: 23
+id: 39
 name: Michael Hutchinson
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Mike-Hutchinson.png'
 website_url: 'https://mikehutchinsonforschoolboard.wordpress.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13218/candidate/130700?&county=Alameda%20County&election_authority_id=1
 first_name: Michael
 last_name: Hutchinson
-ballot_item: 8
-office_election: 8
+ballot_item: 15
+office_election: 15
 bio: >-
   Mike Hutchinson has worked and volunteered in Oakland's public schools for the
   past twenty years and has run programs for non-profit organizations for the
@@ -25,6 +25,7 @@ supporting_money:
   total_contributions: null
   total_expenditures: null
   total_loans_received: null
+  total_supporting_independent: 0
   contributions_by_type: {}
   contributions_by_origin: {}
   expenditures_by_type: {}
@@ -38,7 +39,5 @@ total_expenditures: null
 total_loans_received: null
 contributions_by_type: {}
 expenditures_by_type: {}
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Mike Hutchinson has worked and volunteered in Oakland's public schools for the past twenty years and has run programs for non-profit organizations for the past nine years. Hutchinson is an Oakland resident who attended UC Berkeley.

--- a/_candidates/mya-whitaker.md
+++ b/_candidates/mya-whitaker.md
@@ -1,0 +1,38 @@
+---
+id: 22
+name: Mya Whitaker
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Mya
+last_name: Whitaker
+ballot_item: 8
+office_election: 8
+bio: null
+committee_name: No committee registered
+is_accepted_expenditure_ceiling: true
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: null
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/nancy-sidebotham.md
+++ b/_candidates/nancy-sidebotham.md
@@ -30,6 +30,7 @@ supporting_money:
   total_contributions: 396
   total_expenditures: 646
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Unitemized: 396
   contributions_by_origin: {}
@@ -51,8 +52,6 @@ expenditures_by_type:
   Office Expenses: 145.97
   Campaign Paraphernalia/Misc.: 310.03
   Candidate Filing/Ballot Fees: 190
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Nancy Sidebotham has lived and worked in Oakland since 1964. She served for 15 years as Chairperson of the Neighborhood Crime Prevention Committee (NCPC) for beat 29X, on the Community Policing Advisory Board (CPAB), and on Neighborhood Watch. Sidebotham graduated from Merritt College in 1968 and California State University Hayward in 1970. 
 

--- a/_candidates/natasha-middleton.md
+++ b/_candidates/natasha-middleton.md
@@ -1,0 +1,38 @@
+---
+id: 30
+name: Natasha Middleton
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Natasha
+last_name: Middleton
+ballot_item: 8
+office_election: 8
+bio: null
+committee_name: Natasha Middleton for Oakland City Council
+is_accepted_expenditure_ceiling: true
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: 1403124
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/nehanda-imara.md
+++ b/_candidates/nehanda-imara.md
@@ -1,5 +1,5 @@
 ---
-id: 14
+id: 23
 name: Nehanda Imara
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Nehanda_Imara.png'
 website_url: 'http://www.nehandafordistrict7.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13238/candidate/130762?&county=Alameda%20County&election_authority_id=1
 first_name: Nehanda
 last_name: Imara
-ballot_item: 7
-office_election: 7
+ballot_item: 9
+office_election: 9
 bio: >-
   Nehanda Imara is an Oakland resident, organizer, educator and adjunct teacher
   for African American and Environmental Studies at Merritt College. She is a
@@ -32,6 +32,7 @@ supporting_money:
   total_contributions: 27941
   total_expenditures: 35137.46
   total_loans_received: 6500
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 1700
     Individual: 16550
@@ -70,8 +71,6 @@ expenditures_by_type:
   Campaign Literature and Mailings: 7287.36
   'Postage, Delivery and Messenger Services': 3818.95
   'Professional Services (Legal, Accounting)': 3147.37
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Nehanda Imara is an Oakland resident, organizer, educator and adjunct teacher for African American and Environmental Studies at Merritt College. She is a Community Organizer for Communities for a Better Environment. She is a member of the Board of Directors of Leadership Excellence, a non-profit African American youth organization in Oakland and member of the East Oakland Building Healthy Community initiative. Imara also serves as Co-coordinator of Merritt’s “Black Consciousness Raising Tours of Africa and the African Diaspora.  
 

--- a/_candidates/nikki-fortunato-bas.md
+++ b/_candidates/nikki-fortunato-bas.md
@@ -1,0 +1,54 @@
+---
+id: 18
+name: Nikki Fortunato Bas
+photo_url: >-
+  https://d3n8a8pro7vhmx.cloudfront.net/nikki4oakland/pages/34/attachments/original/1513124836/NikkiLaunch-December17.png?1513124836
+website_url: 'http://www.nikki4oakland.com/launch'
+twitter_url: Nikki4Oakland
+votersedge_url: null
+first_name: Nikki
+last_name: Fortunato Bas
+ballot_item: 5
+office_election: 5
+bio: null
+committee_name: Nikki Fortunato Bas for Oakland City Council 2018
+is_accepted_expenditure_ceiling: true
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: 1400325
+supporting_money:
+  contributions_received: 43000
+  total_contributions: 43000
+  total_expenditures: 3729.35
+  total_loans_received: 0
+  total_supporting_independent: 0
+  contributions_by_type:
+    Individual: 37951
+    Unitemized: 5049
+  contributions_by_origin:
+    Out of State: 6300
+    Within Oakland: 22901
+    Within California: 8750
+  expenditures_by_type:
+    Not Stated: 2245.31
+    Office Expenses: 118.87
+    'Postage, Delivery and Messenger Services': 29.69
+    'Professional Services (Legal, Accounting)': 1228.19
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: 43000
+total_contributions: 43000
+total_expenditures: 3729.35
+total_loans_received: 0
+contributions_by_type:
+  Individual: 37951
+  Unitemized: 5049
+expenditures_by_type:
+  Not Stated: 2245.31
+  Office Expenses: 118.87
+  'Postage, Delivery and Messenger Services': 29.69
+  'Professional Services (Legal, Accounting)': 1228.19
+---

--- a/_candidates/noel-gallo.md
+++ b/_candidates/noel-gallo.md
@@ -1,5 +1,5 @@
 ---
-id: 11
+id: 15
 name: Noel Gallo
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Noel-Gallo.png'
 website_url: 'http://galloforoakland.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13237/candidate/130759?&county=Alameda%20County&election_authority_id=1
 first_name: Noel
 last_name: Gallo
-ballot_item: 10
-office_election: 10
+ballot_item: 7
+office_election: 7
 bio: >-
   Noel Gallo was elected to the Oakland City Council in 2012 to represent
   District 5. He serves as Co-Chair of the Oakland City Council Education
@@ -33,8 +33,9 @@ filer_id: 1388641
 supporting_money:
   contributions_received: 80100.69
   total_contributions: 80100.69
-  total_expenditures: 86946.74
+  total_expenditures: 87107.1
   total_loans_received: 10000
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 9200
     Individual: 22350
@@ -48,7 +49,7 @@ supporting_money:
     Print Ads: 500
     Not Stated: 10826.1
     Contribution: 550
-    Civic Donations: 700
+    Civic Donations: 860.36
     Office Expenses: 3595.76
     Fundraising Events: 656.55
     Campaign Workers' Salaries: 3000
@@ -71,7 +72,7 @@ opposing_money:
     Mailing and Postage in opposition to Noel Gallo: 7398
 contributions_received: 80100.69
 total_contributions: 80100.69
-total_expenditures: 86946.74
+total_expenditures: 87107.1
 total_loans_received: 10000
 contributions_by_type:
   Committee: 9200
@@ -82,7 +83,7 @@ expenditures_by_type:
   Print Ads: 500
   Not Stated: 10826.1
   Contribution: 550
-  Civic Donations: 700
+  Civic Donations: 860.36
   Office Expenses: 3595.76
   Fundraising Events: 656.55
   Campaign Workers' Salaries: 3000
@@ -90,8 +91,6 @@ expenditures_by_type:
   Candidate Filing/Ballot Fees: 300
   Campaign Literature and Mailings: 36593.49
   'Professional Services (Legal, Accounting)': 21788
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Noel Gallo was elected to the Oakland City Council in 2012 to represent District 5. He serves as Co-Chair of the Oakland City Council Education Partnership Committee, and a member of the Life Enrichment, Public Works, and Public Safety City Council Committees. He represents the City of Oakland as a member of the AC Transit Bus Rapid Transit (BRT) Policy Steering Committee. Prior to joining the council, Gallo was elected and served on the Oakland Board of Education for 20 years. 
 Gallo is a lifelong resident of Oakland; he grew up in the Fruitvale/San Antonio District neighborhoods. He graduated from the University of California, Berkeley, with a Business Degree. 

--- a/_candidates/noni-session.md
+++ b/_candidates/noni-session.md
@@ -1,5 +1,5 @@
 ---
-id: 10
+id: 14
 name: Noni Session
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Noni-Session2.png'
 website_url: 'http://www.nonifordistrict3.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13236/candidate/130758?&county=Alameda%20County&election_authority_id=1
 first_name: Noni
 last_name: Session
-ballot_item: 2
-office_election: 2
+ballot_item: 6
+office_election: 6
 bio: >-
   Noni Session is a lifelong resident of Oakland and attended Oakland public
   schools. Session served as a special education teacher at Harbor Way Academy
@@ -34,6 +34,7 @@ supporting_money:
   total_contributions: 10634
   total_expenditures: 9611.19
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Individual: 7110
     Unitemized: 1424
@@ -72,8 +73,6 @@ expenditures_by_type:
   Candidate Filing/Ballot Fees: 300
   Campaign Literature and Mailings: 3399.31
   'Information Technology Costs (Internet, E-mail)': 387
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Noni Session is a lifelong resident of Oakland and attended Oakland public schools. Session served as a special education teacher at Harbor Way Academy Elementary School. She graduated with a degree in Cultural Anthropology and African American Studies from San Francisco State University and received her Ph.D. in Cultural Anthropology from Cornell University. Session’s doctoral research in Nairobi, Kenya on Bureaucratic Organizations & Humanitarianism led her to work with the United Nations Development Programme as a Researcher and Government Liaison. 
 

--- a/_candidates/peggy-moore.md
+++ b/_candidates/peggy-moore.md
@@ -29,6 +29,7 @@ supporting_money:
   total_contributions: 316892.58
   total_expenditures: 402322.71
   total_loans_received: 0
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 10100
     Individual: 263596.14
@@ -77,8 +78,6 @@ expenditures_by_type:
   'Professional Services (Legal, Accounting)': 25072.65
   T.V. or Cable Airtime and Production Costs: 135000
   'Information Technology Costs (Internet, E-mail)': 9961.9
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Peggy Moore has served as a Senior Advisor to Oakland Mayor Libby Schaaf and as California Political Director for two winning presidential campaigns. She grew up in Oklahoma City and moved to Oakland in 1990. She has held leadership roles in LGBTQ and African American organizations. 
 

--- a/_candidates/rafael-mandelman.md
+++ b/_candidates/rafael-mandelman.md
@@ -1,39 +1,73 @@
 ---
-id: 29
+id: 48
 name: Rafael Mandelman
 photo_url: null
-website_url: "http://www.rafaelmandelman.com/"
+website_url: null
 twitter_url: null
 votersedge_url: null
 first_name: Rafael
 last_name: Mandelman
-ballot_item: 16
-office_election: 16
+ballot_item: 17
+office_election: 17
 bio: null
 committee_name: Rafael Mandelman for Supervisor 2018 Primary
 is_accepted_expenditure_ceiling: null
 is_incumbent: null
 occupation: null
 party_affiliation: null
-filer_id: null
+filer_id: 1395947
 supporting_money:
-  contributions_received: null
-  total_contributions: null
-  total_expenditures: null
-  total_loans_received: null
-  contributions_by_type: {}
-  contributions_by_origin: {}
-  expenditures_by_type: {}
+  contributions_received: 254022.27
+  total_contributions: 254022.27
+  total_expenditures: 175286.1
+  total_loans_received: 0
+  total_supporting_independent: 0
+  contributions_by_type:
+    Committee: 1000
+    Individual: 238856.01
+    Unitemized: 13566.26
+    Other (includes Businesses): 600
+  contributions_by_origin:
+    Out of State: 13610
+    Within Oakland: 4425
+    Within California: 222421.01
+  expenditures_by_type:
+    Not Stated: 55000
+    Office Expenses: 10262.69
+    Fundraising Events: 8954.81
+    Campaign Consultants: 8750
+    Meetings and Appearances: 250
+    Campaign Workers' Salaries: 42967.21
+    Campaign Paraphernalia/Misc.: 19514.82
+    Candidate Filing/Ballot Fees: 250
+    'Staff/Spouse Travel, Lodging, and Meals': 173.99
+    'Postage, Delivery and Messenger Services': 254.8
+    'Professional Services (Legal, Accounting)': 18360.75
+    'Information Technology Costs (Internet, E-mail)': 6625.57
   supporting_by_type: {}
 opposing_money:
   opposing_expenditures: null
   opposing_by_type: {}
-contributions_received: null
-total_contributions: null
-total_expenditures: null
-total_loans_received: null
-contributions_by_type: {}
-expenditures_by_type: {}
-ballots:
-- _ballots/san-francisco/2018-06-05.md
+contributions_received: 254022.27
+total_contributions: 254022.27
+total_expenditures: 175286.1
+total_loans_received: 0
+contributions_by_type:
+  Committee: 1000
+  Individual: 238856.01
+  Unitemized: 13566.26
+  Other (includes Businesses): 600
+expenditures_by_type:
+  Not Stated: 55000
+  Office Expenses: 10262.69
+  Fundraising Events: 8954.81
+  Campaign Consultants: 8750
+  Meetings and Appearances: 250
+  Campaign Workers' Salaries: 42967.21
+  Campaign Paraphernalia/Misc.: 19514.82
+  Candidate Filing/Ballot Fees: 250
+  'Staff/Spouse Travel, Lodging, and Meals': 173.99
+  'Postage, Delivery and Messenger Services': 254.8
+  'Professional Services (Legal, Accounting)': 18360.75
+  'Information Technology Costs (Internet, E-mail)': 6625.57
 ---

--- a/_candidates/rebecca-kaplan.md
+++ b/_candidates/rebecca-kaplan.md
@@ -28,6 +28,7 @@ supporting_money:
   total_contributions: 169231.99
   total_expenditures: 175382.48
   total_loans_received: 4000
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 18570
     Individual: 70440
@@ -80,7 +81,5 @@ expenditures_by_type:
   'Professional Services (Legal, Accounting)': 6863.38
   T.V. or Cable Airtime and Production Costs: 8000
   'Information Technology Costs (Internet, E-mail)': 4170.18
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Rebecca Kaplan was elected Councilmember-at-Large in 2008 and re-elected in 2012. Before joining the Oakland City Council, she served as an elected Director on the AC Transit Board and worked as housing rights attorney in Oakland. Kaplan holds a Juris Doctorate in Law from Stanford Law School and a Master of Arts in Urban & Environmental Policy from Tufts University. Source: Candidate Statement and campaign website.

--- a/_candidates/roseann-torres.md
+++ b/_candidates/roseann-torres.md
@@ -1,5 +1,5 @@
 ---
-id: 24
+id: 40
 name: Roseann Torres
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Roseann-Torres.png'
 website_url: 'https://www.facebook.com/torresforschoolboard/home?ref=page_internal'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13218/candidate/130701?&county=Alameda%20County&election_authority_id=1
 first_name: Roseann
 last_name: Torres
-ballot_item: 8
-office_election: 8
+ballot_item: 15
+office_election: 15
 bio: >-
   Rosie Torres is running for re-election to represent District 5 for Oakland
   School Board. Torres was elected to represent Oakland’s District 5 schools in
@@ -29,6 +29,7 @@ supporting_money:
   total_contributions: 36273.01
   total_expenditures: 47922.55
   total_loans_received: 9250
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 6500
     Individual: 16225.01
@@ -74,8 +75,6 @@ expenditures_by_type:
   'Postage, Delivery and Messenger Services': 740.46
   'Professional Services (Legal, Accounting)': 8500.24
   'Information Technology Costs (Internet, E-mail)': 400
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  
 

--- a/_candidates/saied-karamooz.md
+++ b/_candidates/saied-karamooz.md
@@ -1,0 +1,38 @@
+---
+id: 31
+name: Saied Karamooz
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Saied
+last_name: Karamooz
+ballot_item: 10
+office_election: 10
+bio: null
+committee_name: Saied Karamooz for Oakland Mayor 2018
+is_accepted_expenditure_ceiling: false
+is_incumbent: false
+occupation: null
+party_affiliation: null
+filer_id: 1401694
+supporting_money:
+  contributions_received: null
+  total_contributions: null
+  total_expenditures: null
+  total_loans_received: null
+  total_supporting_independent: 0
+  contributions_by_type: {}
+  contributions_by_origin: {}
+  expenditures_by_type: {}
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: null
+total_contributions: null
+total_expenditures: null
+total_loans_received: null
+contributions_by_type: {}
+expenditures_by_type: {}
+---

--- a/_candidates/shanthi-gonzales.md
+++ b/_candidates/shanthi-gonzales.md
@@ -1,0 +1,51 @@
+---
+id: 45
+name: Shanthi Gonzales
+photo_url: null
+website_url: null
+twitter_url: null
+votersedge_url: null
+first_name: Shanthi
+last_name: Gonzales
+ballot_item: 12
+office_election: 12
+bio: null
+committee_name: Gonzales for School Board 2018
+is_accepted_expenditure_ceiling: true
+is_incumbent: true
+occupation: null
+party_affiliation: null
+filer_id: 1364457
+supporting_money:
+  contributions_received: 8250
+  total_contributions: 8250
+  total_expenditures: 1452.91
+  total_loans_received: 0
+  total_supporting_independent: 0
+  contributions_by_type:
+    Committee: 6400
+    Individual: 1650
+    Unitemized: -50
+    Other (includes Businesses): 250
+  contributions_by_origin:
+    Out of State: 500
+    Within Oakland: 2900
+    Within California: 4900
+  expenditures_by_type:
+    Contribution: 1400
+  supporting_by_type: {}
+opposing_money:
+  opposing_expenditures: null
+  opposing_by_type: {}
+contributions_received: 8250
+total_contributions: 8250
+total_expenditures: 1452.91
+total_loans_received: 0
+contributions_by_type:
+  Committee: 6400
+  Individual: 1650
+  Unitemized: -50
+  Other (includes Businesses): 250
+expenditures_by_type:
+  Contribution: 1400
+---

--- a/_candidates/viola-gonzales.md
+++ b/_candidates/viola-gonzales.md
@@ -1,5 +1,5 @@
 ---
-id: 12
+id: 16
 name: Viola Gonzales
 photo_url: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Viola-Gonzales.png'
 website_url: 'http://www.voteviola.com/'
@@ -8,8 +8,8 @@ votersedge_url: >-
   http://votersedge.org/ca/en/ballot/election/area/42/contests/contest/13237/candidate/130760?&county=Alameda%20County&election_authority_id=1
 first_name: Viola
 last_name: Gonzales
-ballot_item: 10
-office_election: 10
+ballot_item: 7
+office_election: 7
 bio: >-
   Viola Gonzales was the Chief Executive Officer of AnewAmerica Community
   Corporation, a non-profit that helps immigrants and refugees start small and
@@ -37,6 +37,7 @@ supporting_money:
   total_contributions: 69742.41
   total_expenditures: 69842.41
   total_loans_received: 6899.83
+  total_supporting_independent: 0
   contributions_by_type:
     Committee: 4700
     Individual: 43517.84
@@ -77,8 +78,6 @@ expenditures_by_type:
   Campaign Literature and Mailings: 33656.76
   'Professional Services (Legal, Accounting)': 4504.52
   'Information Technology Costs (Internet, E-mail)': 3150
-ballots:
-- _ballots/oakland/2016-11-08.md
 ---
 Viola Gonzales was the Chief Executive Officer of AnewAmerica Community Corporation, a non-profit that helps immigrants and refugees start small and micro-businesses. Gonzales has been Executive Director for a non-profit residential program for developmentally disabled kids based in Oakland for the past eight years. Her volunteer service has included corporate advisory, nonprofit and civic boards. In 2002, Gonzales was appointed to the Oakland Board of Education by then-Mayor Jerry Brown. Prior to this appointment, she served on the Oakland Planning Commission. 
 

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -41,11 +41,24 @@ layout: default
         <div class="candidate__summary candidate__summary--balance">Current balance: <span class="money">{{ candidate.total_contributions | minus: candidate.total_expenditures | minus: candidate.total_loans_received | times: 100 | money }}</span></div>
       </div>
     </section>
+    {% assign expenditures_against = candidate.opposing_money.opposing_expenditures %}
+    {% assign independent_expenditures_for = candidate.supporting_money.total_supporting_independent %}
+    {% if expenditures_against > 0 or independent_expenditures_for > 0 %}
     <section class="l-section">
       <div class="l-section__content">
-        <h2 class="candidate__expenditures-opposing">Expenditures opposing candidate <span class="money">{{ candidate.opposing_money.opposing_expenditures | times: 100 | money }}</span></h2>
+        {% if expenditures_against > 0 %}
+        <h2 class="candidate__expenditures-opposing">
+          Expenditures opposing candidate <span class="money">{{ expenditures_against | times: 100 | money }}</span>
+        </h2>
+        {% endif %}
+        {% if independent_expenditures_for > 0 %}
+        <h2 class="candidate__expenditures-opposing">
+          Expenditures supporting candidate <span class="money">{{ independent_expenditures_for | times: 100 | money }}</span>
+        </h2>
+        {% endif %}
       </div>
     </section>
+    {% endif %}
     {% assign money_bar_max = candidate.total_contributions | plus: candidate.total_expenditures %}
     <section class="l-section">
       <div class="l-section__content l-section__content--half">

--- a/_office_elections/oakland/2018-11-06/city-council-district-2.md
+++ b/_office_elections/oakland/2018-11-06/city-council-district-2.md
@@ -1,0 +1,8 @@
+---
+name: City Council District 2
+candidates:
+  - abel-guillen
+  - annie-campbell-washington
+  - nikki-fortunato-bas
+ballot: _ballots/oakland/2018-11-06.md
+---

--- a/_office_elections/oakland/2018-11-06/city-council-district-6.md
+++ b/_office_elections/oakland/2018-11-06/city-council-district-6.md
@@ -1,0 +1,10 @@
+---
+name: City Council District 6
+candidates:
+  - desley-brooks
+  - loren-taylor
+  - natasha-middleton
+  - maria-rodriguez
+  - mya-whitaker
+ballot: _ballots/oakland/2018-11-06.md
+---

--- a/_office_elections/oakland/2018-11-06/mayor.md
+++ b/_office_elections/oakland/2018-11-06/mayor.md
@@ -4,5 +4,10 @@ candidates:
   - libby-schaaf
   - kristina-molina
   - ken-houston
+  - marchon-tatmon
+  - saied-karamooz
+  - nancy-sidebotham
+  - jesse-a-j-smith
+  - cedric-anthony-troupe
 ballot: _ballots/oakland/2018-11-06.md
 ---

--- a/_referendum_opposing/oakland/2016-11-08/d.md
+++ b/_referendum_opposing/oakland/2016-11-08/d.md
@@ -1,0 +1,14 @@
+---
+id: 7
+contest_type: Referendum
+name: Library Parcel Tax
+title: Library Parcel Tax
+summary: >-
+  This measure would impose an additional parcel tax to fund the Oakland Public
+  Library.
+number: D
+opposing_organizations: []
+total_contributions: []
+contributions_by_region: []
+contributions_by_type: []
+---

--- a/_referendum_opposing/oakland/2016-11-08/g1.md
+++ b/_referendum_opposing/oakland/2016-11-08/g1.md
@@ -1,5 +1,6 @@
 ---
 id: 6
+contest_type: Referendum
 name: Oakland School Bond
 title: Oakland School Bond
 summary: >-
@@ -15,4 +16,5 @@ number: G1
 opposing_organizations: []
 total_contributions: []
 contributions_by_region: []
+contributions_by_type: []
 ---

--- a/_referendum_opposing/oakland/2016-11-08/hh.md
+++ b/_referendum_opposing/oakland/2016-11-08/hh.md
@@ -1,5 +1,6 @@
 ---
 id: 1
+contest_type: Referendum
 name: Sugar-Sweetened BeverageTax
 title: Sugar-Sweetened BeverageTax
 summary: >-
@@ -31,4 +32,9 @@ contributions_by_region:
     locale: Out of State
   - amount: 7905502.73
     locale: Within California
+contributions_by_type:
+  - type: Committee
+    amount: 7906502.73
+  - type: Other (includes Businesses)
+    amount: 7391.91
 ---

--- a/_referendum_opposing/oakland/2016-11-08/ii.md
+++ b/_referendum_opposing/oakland/2016-11-08/ii.md
@@ -1,5 +1,6 @@
 ---
 id: 2
+contest_type: Referendum
 name: Lease Term for City-Owned or City-Controlled Property
 title: Lease Term for City-Owned or City-Controlled Property
 summary: >-
@@ -12,4 +13,5 @@ number: II
 opposing_organizations: []
 total_contributions: []
 contributions_by_region: []
+contributions_by_type: []
 ---

--- a/_referendum_opposing/oakland/2016-11-08/jj.md
+++ b/_referendum_opposing/oakland/2016-11-08/jj.md
@@ -1,5 +1,6 @@
 ---
 id: 3
+contest_type: Referendum
 name: Just Cause for Eviction and Rent Adjustment
 title: Just Cause for Eviction and Rent Adjustment
 summary: >-
@@ -19,4 +20,5 @@ number: JJ
 opposing_organizations: []
 total_contributions: []
 contributions_by_region: []
+contributions_by_type: []
 ---

--- a/_referendum_opposing/oakland/2016-11-08/kk.md
+++ b/_referendum_opposing/oakland/2016-11-08/kk.md
@@ -1,5 +1,6 @@
 ---
 id: 4
+contest_type: Referendum
 name: Infrastructure and Housing bonds
 title: Infrastructure and Housing bonds
 summary: >-
@@ -31,4 +32,11 @@ contributions_by_region:
     locale: Within Oakland
   - amount: 299.6999999999971
     locale: Unknown
+contributions_by_type:
+  - type: Individual
+    amount: 7500
+  - type: Other (includes Businesses)
+    amount: 35274.29
+  - type: COM
+    amount: 299.6999999999971
 ---

--- a/_referendum_opposing/oakland/2016-11-08/ll.md
+++ b/_referendum_opposing/oakland/2016-11-08/ll.md
@@ -1,5 +1,6 @@
 ---
 id: 5
+contest_type: Referendum
 name: Police Commission
 title: Police Commission
 summary: >-
@@ -24,4 +25,5 @@ number: LL
 opposing_organizations: []
 total_contributions: []
 contributions_by_region: []
+contributions_by_type: []
 ---

--- a/_referendum_opposing/oakland/2016-11-08/tbd1.md
+++ b/_referendum_opposing/oakland/2016-11-08/tbd1.md
@@ -1,0 +1,17 @@
+---
+id: 8
+contest_type: Referendum
+name: Oakland Children's Initiative
+title: Oakland Children's Initiative
+summary: >-
+  The initiative is a $198 per parcel tax that would generate $30 million in
+  revenue each year to support early childhood education and the Oakland Promise
+  program. The Oakland Promise program, created two years ago, supports low
+  income children by establishing a college savings accounts at birth and the
+  program provides continued support through school and college.
+number: TBD1
+opposing_organizations: []
+total_contributions: []
+contributions_by_region: []
+contributions_by_type: []
+---

--- a/_referendum_opposing/oakland/2016-11-08/tbd2.md
+++ b/_referendum_opposing/oakland/2016-11-08/tbd2.md
@@ -1,0 +1,12 @@
+---
+id: 9
+contest_type: Referendum
+name: Hotel Protection & Employer Standards
+title: Hotel Protection & Employer Standards
+summary: null
+number: TBD2
+opposing_organizations: []
+total_contributions: []
+contributions_by_region: []
+contributions_by_type: []
+---

--- a/_referendum_supporting/oakland/2016-11-08/d.md
+++ b/_referendum_supporting/oakland/2016-11-08/d.md
@@ -1,0 +1,14 @@
+---
+id: 7
+contest_type: Referendum
+name: Library Parcel Tax
+title: Library Parcel Tax
+summary: >-
+  This measure would impose an additional parcel tax to fund the Oakland Public
+  Library.
+number: D
+supporting_organizations: []
+total_contributions: []
+contributions_by_region: []
+contributions_by_type: []
+---

--- a/_referendum_supporting/oakland/2016-11-08/g1.md
+++ b/_referendum_supporting/oakland/2016-11-08/g1.md
@@ -1,5 +1,6 @@
 ---
 id: 6
+contest_type: Referendum
 name: Oakland School Bond
 title: Oakland School Bond
 summary: >-
@@ -25,7 +26,7 @@ supporting_organizations:
     name: Friends of Oakland Public Schools Yes on G1 2016
     payee: Friends of Oakland Public Schools Yes on G1 2016
     amount: 32926.02
-  - id: '1391632'
+  - id: null
     name: 'YES ON G1, SPONSORED BY GO PUBLIC SCHOOLS ADVOCATES'
     payee: 'YES ON G1, SPONSORED BY GO PUBLIC SCHOOLS ADVOCATES'
     amount: 15018.45
@@ -35,4 +36,11 @@ contributions_by_region:
     locale: Within California
   - amount: 109500
     locale: Within Oakland
+contributions_by_type:
+  - type: Committee
+    amount: 149000
+  - type: Individual
+    amount: 10500
+  - type: Other (includes Businesses)
+    amount: 98000
 ---

--- a/_referendum_supporting/oakland/2016-11-08/hh.md
+++ b/_referendum_supporting/oakland/2016-11-08/hh.md
@@ -1,5 +1,6 @@
 ---
 id: 1
+contest_type: Referendum
 name: Sugar-Sweetened BeverageTax
 title: Sugar-Sweetened BeverageTax
 summary: >-
@@ -29,4 +30,11 @@ contributions_by_region:
     locale: Within California
   - amount: 78680
     locale: Within Oakland
+contributions_by_type:
+  - type: Committee
+    amount: 213964.72
+  - type: Individual
+    amount: 9416327.2
+  - type: Other (includes Businesses)
+    amount: 1129650
 ---

--- a/_referendum_supporting/oakland/2016-11-08/ii.md
+++ b/_referendum_supporting/oakland/2016-11-08/ii.md
@@ -1,5 +1,6 @@
 ---
 id: 2
+contest_type: Referendum
 name: Lease Term for City-Owned or City-Controlled Property
 title: Lease Term for City-Owned or City-Controlled Property
 summary: >-
@@ -12,4 +13,5 @@ number: II
 supporting_organizations: []
 total_contributions: []
 contributions_by_region: []
+contributions_by_type: []
 ---

--- a/_referendum_supporting/oakland/2016-11-08/jj.md
+++ b/_referendum_supporting/oakland/2016-11-08/jj.md
@@ -1,5 +1,6 @@
 ---
 id: 3
+contest_type: Referendum
 name: Just Cause for Eviction and Rent Adjustment
 title: Just Cause for Eviction and Rent Adjustment
 summary: >-
@@ -39,4 +40,13 @@ contributions_by_region:
     locale: Within Oakland
   - amount: 26855.070000000007
     locale: Unknown
+contributions_by_type:
+  - type: Committee
+    amount: 270394.35
+  - type: Individual
+    amount: 49670
+  - type: Other (includes Businesses)
+    amount: 157655.46
+  - type: COM
+    amount: 26855.070000000036
 ---

--- a/_referendum_supporting/oakland/2016-11-08/kk.md
+++ b/_referendum_supporting/oakland/2016-11-08/kk.md
@@ -1,5 +1,6 @@
 ---
 id: 4
+contest_type: Referendum
 name: Infrastructure and Housing bonds
 title: Infrastructure and Housing bonds
 summary: >-
@@ -31,4 +32,11 @@ contributions_by_region:
     locale: Within California
   - amount: 268387.34
     locale: Within Oakland
+contributions_by_type:
+  - type: Committee
+    amount: 176049.34
+  - type: Individual
+    amount: 23188
+  - type: Other (includes Businesses)
+    amount: 207700
 ---

--- a/_referendum_supporting/oakland/2016-11-08/ll.md
+++ b/_referendum_supporting/oakland/2016-11-08/ll.md
@@ -1,5 +1,6 @@
 ---
 id: 5
+contest_type: Referendum
 name: Police Commission
 title: Police Commission
 summary: >-
@@ -36,4 +37,13 @@ contributions_by_region:
     locale: Within Oakland
   - amount: 483.3100000000013
     locale: Unknown
+contributions_by_type:
+  - type: Committee
+    amount: 9250
+  - type: Individual
+    amount: 17355.5
+  - type: Other (includes Businesses)
+    amount: 1800
+  - type: COM
+    amount: 483.3100000000013
 ---

--- a/_referendum_supporting/oakland/2016-11-08/tbd1.md
+++ b/_referendum_supporting/oakland/2016-11-08/tbd1.md
@@ -1,0 +1,17 @@
+---
+id: 8
+contest_type: Referendum
+name: Oakland Children's Initiative
+title: Oakland Children's Initiative
+summary: >-
+  The initiative is a $198 per parcel tax that would generate $30 million in
+  revenue each year to support early childhood education and the Oakland Promise
+  program. The Oakland Promise program, created two years ago, supports low
+  income children by establishing a college savings accounts at birth and the
+  program provides continued support through school and college.
+number: TBD1
+supporting_organizations: []
+total_contributions: []
+contributions_by_region: []
+contributions_by_type: []
+---

--- a/_referendum_supporting/oakland/2016-11-08/tbd2.md
+++ b/_referendum_supporting/oakland/2016-11-08/tbd2.md
@@ -1,0 +1,12 @@
+---
+id: 9
+contest_type: Referendum
+name: Hotel Protection & Employer Standards
+title: Hotel Protection & Employer Standards
+summary: null
+number: TBD2
+supporting_organizations: []
+total_contributions: []
+contributions_by_region: []
+contributions_by_type: []
+---

--- a/_referendums/oakland/2016-11-08/d.md
+++ b/_referendums/oakland/2016-11-08/d.md
@@ -1,0 +1,12 @@
+---
+id: 7
+contest_type: Referendum
+name: Library Parcel Tax
+title: Library Parcel Tax
+summary: >-
+  This measure would impose an additional parcel tax to fund the Oakland Public
+  Library.
+number: D
+ballot_id: 1
+---
+This measure would impose an additional parcel tax to fund the Oakland Public Library.

--- a/_referendums/oakland/2016-11-08/g1.md
+++ b/_referendums/oakland/2016-11-08/g1.md
@@ -1,7 +1,6 @@
 ---
-locality: oakland
-election: 2016-11-08
 id: 6
+contest_type: Referendum
 name: Oakland School Bond
 title: Oakland School Bond
 summary: >-

--- a/_referendums/oakland/2016-11-08/hh.md
+++ b/_referendums/oakland/2016-11-08/hh.md
@@ -1,7 +1,6 @@
 ---
-locality: oakland
-election: 2016-11-08
 id: 1
+contest_type: Referendum
 name: Sugar-Sweetened BeverageTax
 title: Sugar-Sweetened BeverageTax
 summary: >-

--- a/_referendums/oakland/2016-11-08/ii.md
+++ b/_referendums/oakland/2016-11-08/ii.md
@@ -1,7 +1,6 @@
 ---
-locality: oakland
-election: 2016-11-08
 id: 2
+contest_type: Referendum
 name: Lease Term for City-Owned or City-Controlled Property
 title: Lease Term for City-Owned or City-Controlled Property
 summary: >-

--- a/_referendums/oakland/2016-11-08/jj.md
+++ b/_referendums/oakland/2016-11-08/jj.md
@@ -1,7 +1,6 @@
 ---
-locality: oakland
-election: 2016-11-08
 id: 3
+contest_type: Referendum
 name: Just Cause for Eviction and Rent Adjustment
 title: Just Cause for Eviction and Rent Adjustment
 summary: >-

--- a/_referendums/oakland/2016-11-08/kk.md
+++ b/_referendums/oakland/2016-11-08/kk.md
@@ -1,7 +1,6 @@
 ---
-locality: oakland
-election: 2016-11-08
 id: 4
+contest_type: Referendum
 name: Infrastructure and Housing bonds
 title: Infrastructure and Housing bonds
 summary: >-

--- a/_referendums/oakland/2016-11-08/ll.md
+++ b/_referendums/oakland/2016-11-08/ll.md
@@ -1,7 +1,6 @@
 ---
-locality: oakland
-election: 2016-11-08
 id: 5
+contest_type: Referendum
 name: Police Commission
 title: Police Commission
 summary: >-

--- a/_referendums/oakland/2016-11-08/tbd1.md
+++ b/_referendums/oakland/2016-11-08/tbd1.md
@@ -1,0 +1,15 @@
+---
+id: 8
+contest_type: Referendum
+name: Oakland Children's Initiative
+title: Oakland Children's Initiative
+summary: >-
+  The initiative is a $198 per parcel tax that would generate $30 million in
+  revenue each year to support early childhood education and the Oakland Promise
+  program. The Oakland Promise program, created two years ago, supports low
+  income children by establishing a college savings accounts at birth and the
+  program provides continued support through school and college.
+number: TBD1
+ballot_id: 1
+---
+The initiative is a $198 per parcel tax that would generate $30 million in revenue each year to support early childhood education and the Oakland Promise program. The Oakland Promise program, created two years ago, supports low income children by establishing a college savings accounts at birth and the program provides continued support through school and college.

--- a/_referendums/oakland/2016-11-08/tbd2.md
+++ b/_referendums/oakland/2016-11-08/tbd2.md
@@ -1,0 +1,9 @@
+---
+id: 9
+contest_type: Referendum
+name: Hotel Protection & Employer Standards
+title: Hotel Protection & Employer Standards
+summary: null
+number: TBD2
+ballot_id: 1
+---


### PR DESCRIPTION
[Closes caciviclab/disclosure-backend-static#95]

In that issue, Suzanne noticed that we feature "Expenditures Opposing
Candidate" on the candidate's detail page, however we don't include
Expenditures supporting candidate.

Not many candidates have independent expenditures, but those that do --
Huber Trenado, Jumoke Hodge, and James Harris (three candidates for the
school board) -- have quite a lot (more than $100k each).

This also makes the section conditionally hidden if there are no
independent expenditures for/against the candidate. I'm not confident
this is always the right move (it might be nice for a user to know that
a candidate is receiving no IE money) but it seems like a reasonable
first step since most candidates have zero IE money.