### PR TITLE
Fix referendum finance data

### DIFF
--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -3,7 +3,7 @@ layout: default
 ---
 {% assign referendum = page %}
 {% assign election_day = referendum.election | date: "%Y-%m-%d" %}
-{% assign referendum_id = referendum.number | downcase %}
+{% assign referendum_id = referendum.slug %}
 {% capture supporting_path %}_referendum_supporting/{{ referendum.locality }}/{{ election_day }}/{{ referendum_id }}.md{% endcapture %}
 {% capture opposing_path %}_referendum_opposing/{{ referendum.locality }}/{{ election_day }}/{{ referendum_id }}.md{% endcapture %}
 {% assign supporting = site.referendum_supporting | where: 'path', supporting_path | first %}


### PR DESCRIPTION
Use slug instead of Referendum number since we changed the filenames of
referendums.