### PR TITLE
updated all fonts to sans-serif roboto

### DIFF
--- a/_sass/base/_fonts.scss
+++ b/_sass/base/_fonts.scss
@@ -1,13 +1,13 @@
 $font-family-sans-serif: 'Roboto', sans-serif !default;
-$font-family-serif: 'Crete Round', serif !default;
+// $font-family-serif: 'Crete Round', serif !default;
 
 $font-weight-normal: 400;
 $font-weight-bold: 700;
 
-@mixin font-family-serif($weight: $font-weight-normal) {
-  font-family: $font-family-serif;
-  font-weight: $weight;
-}
+// @mixin font-family-serif($weight: $font-weight-normal) {
+//   font-family: $font-family-serif;
+//   font-weight: $weight;
+// }
 
 @import url(https://fonts.googleapis.com/css?family=Roboto:400,100,300,500,700,900,100italic,300italic,400italic,500italic,700italic,900italic);
 @import url(https://fonts.googleapis.com/css?family=Crete+Round:400,400italic);

--- a/_sass/base/_fonts.scss
+++ b/_sass/base/_fonts.scss
@@ -10,4 +10,4 @@ $font-weight-bold: 700;
 // }
 
 @import url(https://fonts.googleapis.com/css?family=Roboto:400,100,300,500,700,900,100italic,300italic,400italic,500italic,700italic,900italic);
-@import url(https://fonts.googleapis.com/css?family=Crete+Round:400,400italic);
+// @import url(https://fonts.googleapis.com/css?family=Crete+Round:400,400italic);

--- a/_sass/base/_fonts.scss
+++ b/_sass/base/_fonts.scss
@@ -1,13 +1,6 @@
 $font-family-sans-serif: 'Roboto', sans-serif !default;
-// $font-family-serif: 'Crete Round', serif !default;
 
 $font-weight-normal: 400;
 $font-weight-bold: 700;
 
-// @mixin font-family-serif($weight: $font-weight-normal) {
-//   font-family: $font-family-serif;
-//   font-weight: $weight;
-// }
-
 @import url(https://fonts.googleapis.com/css?family=Roboto:400,100,300,500,700,900,100italic,300italic,400italic,500italic,700italic,900italic);
-// @import url(https://fonts.googleapis.com/css?family=Crete+Round:400,400italic);

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -15,7 +15,7 @@ $small-font-size: $font-size-small * 1rem;
 $base-line-height: 1.5 !default;
 $heading-line-height: 1.3 !default;
 
-$heading-font-family: $font-family-serif;
+$heading-font-family: $font-family-sans-serif;
 
 // Define font size in rem with a px fallback
 @mixin font-size($size: $font-size-base) {
@@ -28,15 +28,15 @@ $heading-font-family: $font-family-serif;
   line-height: $heading-line-height;
 
   @if $size == 'h1' {
-    @include font-family-serif();
+    font-family: $font-family-sans-serif;
     font-size: $h1-font-size;
   }
   @if $size == 'h2' {
-    @include font-family-serif();
+    font-family: $font-family-sans-serif;
     font-size: $h2-font-size;
   }
   @if $size == 'h3' {
-    @include font-family-serif();
+    font-family: $font-family-sans-serif;
     font-size: $h3-font-size;
   }
   @if $size == 'h4' {
@@ -90,7 +90,7 @@ a {
 }
 
 .subheading {
-  @include font-family-serif;
+  font-family: $font-family-sans-serif;
   color: $subheading-color;
   font-size: $h4-font-size;
   font-style: italic;

--- a/_sass/module/_brand.scss
+++ b/_sass/module/_brand.scss
@@ -1,5 +1,5 @@
 .brand {
-  font-family: $font-family-serif;
+  font-family: $font-family-sans-serif;
 }
 
 .brand__em {

--- a/_sass/module/_candidate-summary.scss
+++ b/_sass/module/_candidate-summary.scss
@@ -20,12 +20,12 @@
 }
 
 .candidate-summary__occupation {
-  @include font-family-serif;
+  font-family: $font-family-sans-serif;
   color: $color-grey-2;
 }
 
 .candidate-summary__contributions {
-  @include font-family-serif;
+  font-family: $font-family-sans-serif;
   color: $color-grey-4;
   font-size: $h5-font-size;
   font-style: italic;

--- a/_sass/module/_money.scss
+++ b/_sass/module/_money.scss
@@ -1,6 +1,6 @@
 .money {
   color: $color-grey-3;
-  font-family: $font-family-serif;
+  font-family: $font-family-sans-serif;
   text-align: right;
 }
 


### PR DESCRIPTION
Refers to issue #87 . 

This PR replaces any instance of `Crete Round` with `Roboto`. There is still more work to be done to make all headers/weights/sizes match the mockups. 

Removed `@mixin font-family-serif`and replaced all instances of `@includes font-family-serif` with `font-family: $font-family-sans-serif`. Can deleted the commented code in `_fonts.scss`, which is just there for reference.