### PR TITLE
Cleanup "Incumbent" annotations

### DIFF
--- a/_ballots/oakland/2016-11-08.md
+++ b/_ballots/oakland/2016-11-08.md
@@ -5,11 +5,11 @@ locality: oakland
 election: 2016-11-08
 office_elections:
 - _office_elections/oakland/2016-11-08/city-council-district-at-large.md
+- _office_elections/oakland/2016-11-08/city-attorney.md
 - _office_elections/oakland/2016-11-08/city-council-district-1.md
 - _office_elections/oakland/2016-11-08/city-council-district-3.md
 - _office_elections/oakland/2016-11-08/city-council-district-5.md
 - _office_elections/oakland/2016-11-08/city-council-district-7.md
-- _office_elections/oakland/2016-11-08/city-attorney.md
 - _office_elections/oakland/2016-11-08/school-board-district-1.md
 - _office_elections/oakland/2016-11-08/school-board-district-3.md
 - _office_elections/oakland/2016-11-08/school-board-district-5.md

--- a/_candidates/abel-guillen.md
+++ b/_candidates/abel-guillen.md
@@ -7,7 +7,7 @@ votersedge_url: null
 committee_name: Abel Guillen for City Council 2018
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
-occupation: Incumbent, Councilmember
+occupation: Councilmember
 party_affiliation: null
 filer_id: null # 1395580
 ballots:

--- a/_candidates/annie-campbell-washington.md
+++ b/_candidates/annie-campbell-washington.md
@@ -7,7 +7,7 @@ votersedge_url: null
 committee_name: Annie Campbell Washington for Oakland City Council 2018
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
-occupation: Incumbent, Councilmember
+occupation: Councilmember
 party_affiliation: null
 filer_id: null # 1376660
 ballots:

--- a/_candidates/barbara-parker.md
+++ b/_candidates/barbara-parker.md
@@ -8,7 +8,7 @@ votersedge_url: >-
 committee_name: Re-elect City Attorney Barbara Parker 2016
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
-occupation: 'Incumbent, City Attorney'
+occupation: 'City Attorney'
 party_affiliation: Democrat
 filer_id: 1382679
 ballots:

--- a/_candidates/brenda-roberts.md
+++ b/_candidates/brenda-roberts.md
@@ -7,7 +7,7 @@ votersedge_url: null
 committee_name: Brenda Roberts for Oakland City Auditor 2018
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
-occupation: Incumbent, City Auditor
+occupation: City Auditor
 party_affiliation: null
 filer_id: null
 ballots:

--- a/_candidates/dan-kalb.md
+++ b/_candidates/dan-kalb.md
@@ -8,7 +8,7 @@ votersedge_url: >-
 committee_name: Re-Elect Dan Kalb Oakland City Council 2016
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
-occupation: 'Incumbent, City Council member'
+occupation: 'City Council member'
 party_affiliation: Democrat
 filer_id: 1382408
 ballots:

--- a/_candidates/libby-schaaf.md
+++ b/_candidates/libby-schaaf.md
@@ -7,7 +7,7 @@ votersedge_url: ""
 committee_name: Libby Schaaf for Mayor 2018
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
-occupation: 'Incumbent, Mayor'
+occupation: 'Mayor'
 party_affiliation: null
 filer_id: null
 ballots:

--- a/_candidates/lynette-gibson-mcelhaney.md
+++ b/_candidates/lynette-gibson-mcelhaney.md
@@ -9,7 +9,7 @@ votersedge_url: >-
 committee_name: Re-Elect McElhaney for City Council 2016
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
-occupation: 'Incumbent, City Council member'
+occupation: 'City Council member'
 party_affiliation: Democrat
 filer_id: 1375179
 ballots:

--- a/_candidates/noel-gallo.md
+++ b/_candidates/noel-gallo.md
@@ -8,7 +8,7 @@ votersedge_url: >-
 committee_name: ReElect Noel Gallo for Oakland City Council 2016
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
-occupation: 'Incumbent, City Council member'
+occupation: 'City Council member'
 party_affiliation: Democrat
 filer_id: 1388641
 ballots:

--- a/_candidates/rebecca-kaplan.md
+++ b/_candidates/rebecca-kaplan.md
@@ -8,7 +8,7 @@ votersedge_url: >-
 committee_name: Kaplan for Oakland City Council 2016
 is_accepted_expenditure_ceiling: true
 is_incumbent: true
-occupation: 'Incumbent, City Council member At-Large'
+occupation: 'City Council member At-Large'
 party_affiliation: Democrat
 filer_id: 1381183
 ballots:

--- a/_candidates/roseann-torres.md
+++ b/_candidates/roseann-torres.md
@@ -8,7 +8,7 @@ votersedge_url: >-
 committee_name: Roseann Torres for Oakland School Board 2016
 is_accepted_expenditure_ceiling: null
 is_incumbent: true
-occupation: Incumbent
+occupation: Oakland School Board member
 party_affiliation: Democrat
 filer_id: 1379121
 ballots:

--- a/_includes/candidate-summary.html
+++ b/_includes/candidate-summary.html
@@ -7,7 +7,7 @@
   </div>
   <div class="candidate-summary__right">
     <div><a href="{{ candidate.url | prepend: site.baseurl }}">{{ candidate.name | escape }}</a></div>
-    <div class="candidate-summary__occupation">{{ candidate.occupation | escape }}</div>
+    <div class="candidate-summary__occupation">{% if candidate.is_incumbent %}Incumbent, {% endif %}{{ candidate.occupation | escape }}</div>
     <div class="candidate-summary__contributions">amount collected <span class="money">{{ finance.total_contributions | dollars }}</span></div>
   </div>
 </div>

--- a/_office_elections/oakland/2016-11-08/city-council-district-1.md
+++ b/_office_elections/oakland/2016-11-08/city-council-district-1.md
@@ -1,7 +1,7 @@
 ---
 name: City Council District 1
 candidates:
-  - kevin-corbett
   - dan-kalb
+  - kevin-corbett
 ballot: _ballots/oakland/2016-11-08.md
 ---

--- a/_office_elections/oakland/2016-11-08/city-council-district-7.md
+++ b/_office_elections/oakland/2016-11-08/city-council-district-7.md
@@ -1,8 +1,8 @@
 ---
 name: City Council District 7
 candidates:
+  - larry-reid
   - marcie-hodge
   - nehanda-imara
-  - larry-reid
 ballot: _ballots/oakland/2016-11-08.md
 ---

--- a/_office_elections/oakland/2016-11-08/school-board-district-1.md
+++ b/_office_elections/oakland/2016-11-08/school-board-district-1.md
@@ -1,7 +1,7 @@
 ---
 name: School Board District 1
 candidates:
-  - donald-macleay
   - jody-london
+  - donald-macleay
 ballot: _ballots/oakland/2016-11-08.md
 ---

--- a/_office_elections/oakland/2016-11-08/school-board-district-5.md
+++ b/_office_elections/oakland/2016-11-08/school-board-district-5.md
@@ -1,9 +1,9 @@
 ---
 name: School Board District 5
 candidates:
+  - roseann-torres
   - michael-hassid
   - michael-hutchinson
-  - roseann-torres
   - huber-trenado
 ballot: _ballots/oakland/2016-11-08.md
 ---


### PR DESCRIPTION
- Show incumbent on the office election list
- Remove "Incumbent" from occupation (since it's redundant).
- Move City Attorney higher in the ballot for Oakland Nov '16 election.

This fixes https://github.com/caciviclab/disclosure-frontend/issues/164