### PR TITLE
November 2018 Oakland referendums

### DIFF
--- a/_ballots/oakland/2018-11-06.md
+++ b/_ballots/oakland/2018-11-06.md
@@ -8,5 +8,7 @@ office_elections:
 - _office_elections/oakland/2018-11-06/city-council-district-2.md
 - _office_elections/oakland/2018-11-06/city-council-district-6.md
 - _office_elections/oakland/2018-11-06/ousd-district-6.md
-referendums: []
+referendums:
+- _referendums/oakland/2018-11-06/hotel-protection-employer-standards.md
+- _referendums/oakland/2018-11-06/oakland-childrens-initiative.md
 ---

--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -10,7 +10,7 @@
         <h3>{% include referendum_measure_heading.html referendum_measure_display=locality.referendum_measure_display %}</h3>
         {% for ballot_item in referendums %}
           {% assign referendum = site.referendums | where: "path", ballot_item | first %}
-          <p><a href="{{ referendum.url | prepend: site.baseurl }}">{{ referendum.number }} {{ referendum.title | escape}}</a></p>
+          <p><a href="{{ referendum.url | prepend: site.baseurl }}">{% if referendum.number %}{{ referendum.number }} {% endif %}{{ referendum.title | escape}}</a></p>
         {% endfor %}
       </div>
     </section>

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -3,7 +3,7 @@ layout: default
 ---
 {% assign referendum = page %}
 {% assign election_day = referendum.election | date: "%Y-%m-%d" %}
-{% assign referendum_id = referendum.title | slugify %}
+{% assign referendum_id = referendum.title | slugify: "pretty" %}
 {% assign supporting = site.data.referendum_supporting[referendum.locality][election_day][referendum_id] %}
 {% assign opposing = site.data.referendum_opposing[referendum.locality][election_day][referendum_id] %}
 {% capture ballot_path %}_ballots/{{ referendum.locality }}/{{ election_day }}.md{% endcapture %}

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -12,8 +12,13 @@ layout: default
 
 {% capture body %}
 <header>
-  <h1>Measure {{ referendum.number }}</h1>
-  <h2>{{ referendum.title }}</h2>
+  {% if referendum.number %}
+    <h1>Measure {{ referendum.number }}</h1>
+    <h2>{{ referendum.title | escape }}</h2>
+  {% else %}
+    <h1>{{ referendum.title | escape }}</h1>
+    <div><i>No measure number has been assigned.</i></div>
+  {% endif %}
 </header>
 <section class="l-section">
   {{ referendum.content }}

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -17,13 +17,14 @@ layout: default
     <h2>{{ referendum.title | escape }}</h2>
   {% else %}
     <h1>{{ referendum.title | escape }}</h1>
-    <div><i>No measure number has been assigned.</i></div>
+    <div><p><i>No measure number has been assigned.</i></p></div>
   {% endif %}
 </header>
 <section class="l-section">
   {{ referendum.content }}
 </section>
 
+{% if supporting or opposing %}
 <!-- supporting money column -->
 <section class="l-section">
   <div class="l-section__content l-section__content--half">
@@ -88,6 +89,13 @@ layout: default
     {% include supporting_opposing_committees.html committees=opposing.opposing_organizations color="red" %}
   </div>
 </section>
+{% else %}
+<section class="l-section">
+  <div class="l-section__content">
+    <p><i>No filings have been reported for this ballot measure.</i></p>
+  </div>
+</section>
+{% endif %}
 
 {% endcapture %}
 {% include ballot-layout.html content=body ballot=ballot locality=locality %}

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -24,7 +24,7 @@ layout: default
   {{ referendum.content }}
 </section>
 
-{% if supporting or opposing %}
+{% if supporting.total_contributions > 0 or opposing.total_contributions > 0 %}
 <!-- supporting money column -->
 <section class="l-section">
   <div class="l-section__content l-section__content--half">

--- a/_referendums/oakland/2018-11-06/hotel-protection-employer-standards.md
+++ b/_referendums/oakland/2018-11-06/hotel-protection-employer-standards.md
@@ -2,5 +2,4 @@
 locality: oakland
 election: 2018-11-06
 title: Hotel Protection & Employer Standards
-number: TBD2
 ---

--- a/_referendums/oakland/2018-11-06/oakland-childrens-initiative.md
+++ b/_referendums/oakland/2018-11-06/oakland-childrens-initiative.md
@@ -2,6 +2,5 @@
 locality: oakland
 election: 2018-11-06
 title: Oakland Children's Initiative
-number: TBD1
 ---
 The initiative is a $198 per parcel tax that would generate $30 million in revenue each year to support early childhood education and the Oakland Promise program. The Oakland Promise program, created two years ago, supports low income children by establishing a college savings accounts at birth and the program provides continued support through school and college.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ function dataDir(...pathParts) {
 
 
 function slugify(text) {
-  return (text || '').toLowerCase().replace(/[\.']+/g, '').replace(/[^a-z0-9-]+/g, '-');
+  return (text || '').toLowerCase().replace(/[\._~!$&'()+,;=@]+/g, '').replace(/[^a-z0-9-]+/g, '-');
 }
 
 function slugifyName(fn) {


### PR DESCRIPTION
Shows the November 2018 Oakland referendums in the nav when looking at the [2018 page](https://caciviclab.org/odca-jekyll/election/oakland/2018-11-06/).

- Remove the measure number, add conditional logic when the number hasn't been assigned.
- Hide the finance sections when no finance data exists
- Update the slugify logic to match pull-finance with how jekyll works