### PR TITLE
Responsive candidate photos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "jekyll", "~> 3.6.2"
 gem "html-proofer"
 gem "neat"
 gem "scss_lint"
+gem "mini_magick"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
+    mini_magick (4.8.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     neat (2.1.0)
@@ -119,6 +120,7 @@ DEPENDENCIES
   jekyll-assets
   jekyll-feed (~> 0.6)
   jekyll-seo-tag
+  mini_magick
   neat
   scss_lint
   tzinfo-data

--- a/_includes/candidate-photo.html
+++ b/_includes/candidate-photo.html
@@ -1,0 +1,8 @@
+{%- assign class = include.class -%}
+{%- assign alt = include.candidate.name | smartify | escape -%}
+{%- assign photo_url = include.candidate.photo_url | default: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/no-image.png' -%}
+{%- if photo_url contains '://' -%}
+<img class="{{ class }}" src="{{ photo_url }}" alt="{{ alt }}" />
+{%- else -%}
+<img class="{{ class }}" src="{{ photo_url | prepend: site.baseurl }}" alt="{{ alt }}" />
+{%- endif -%}

--- a/_includes/candidate-photo.html
+++ b/_includes/candidate-photo.html
@@ -4,5 +4,10 @@
 {%- if photo_url contains '://' -%}
 <img class="{{ class }}" src="{{ photo_url }}" alt="{{ alt }}" />
 {%- else -%}
-<img class="{{ class }}" src="{{ photo_url | prepend: site.baseurl }}" alt="{{ alt }}" />
+{% asset 'candidates/{{ photo_url }}'
+   class="{{ class }}"
+   alt="{{ alt }}"
+   srcset:width="600 2x"
+   srcset:width="450 1.5x"
+   srcset:width="300 1x" %}
 {%- endif -%}

--- a/_includes/candidate-summary.html
+++ b/_includes/candidate-summary.html
@@ -3,7 +3,7 @@
 
 <div class="candidate-summary">
   <div class="candidate-summary__left">
-    <img class="candidate-summary__photo" src="{{ candidate.photo_url | default: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/no-image.png' }}" alt="{{ candidate.name | smartify | escape }}" />
+    {% include candidate-photo.html candidate=candidate class="candidate-summary__photo" %}
   </div>
   <div class="candidate-summary__right">
     <div><a href="{{ candidate.url | prepend: site.baseurl }}">{{ candidate.name | smartify | escape }}</a></div>

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -18,7 +18,7 @@ layout: default
     <section class="l-section">
       <div class="l-section__content">
         <div class="candidate__info-container">
-          <img class="candidate__photo" src="{{ candidate.photo_url | default: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/no-image.png' }}" alt="{{ candidate.name | smartify | escape }}" />
+          {% include candidate-photo.html candidate=candidate class="candidate__photo" %}
           <div class="candidate__info">
             <div class="candidate__occupation-commitee-name">{% if candidate.is_incumbent == true and candidate.committee_name != null %}
               Incumbent |


### PR DESCRIPTION
Use mini_magick and jekyll-assets to resize candidate photos, creating low-density image for lower-res devices.