### PR TITLE
Transliterate non-latin characters in slug

### DIFF
--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -3,7 +3,7 @@ layout: default
 ---
 {% assign referendum = page %}
 {% assign election_day = referendum.election | date: "%Y-%m-%d" %}
-{% assign referendum_id = referendum.title | odca_slugify %}
+{% assign referendum_id = referendum.title | slugify: 'latin' %}
 {% assign supporting = site.data.referendum_supporting[referendum.locality][election_day][referendum_id] %}
 {% assign opposing = site.data.referendum_opposing[referendum.locality][election_day][referendum_id] %}
 {% capture ballot_path %}_ballots/{{ referendum.locality }}/{{ election_day }}.md{% endcapture %}

--- a/_plugins/odca_slugify.rb
+++ b/_plugins/odca_slugify.rb
@@ -1,9 +1,0 @@
-module Jekyll
-  module ODCASlugify
-    def odca_slugify(text)
-      (text || '').downcase.gsub(/[\._~!$&'()+,;=@]+/, '').gsub(/[^a-z0-9-]+/, '-')
-    end
-  end
-end
-
-Liquid::Template.register_filter(Jekyll::ODCASlugify)


### PR DESCRIPTION
This matches the back end behavior. We have to use the same slug in order to
find the referendum finance data. Would be nice if we had a key/id to match
instead.

This is the only location where the slugify function has to match the back end and there's no need for a custom slugify funciton.