### PR TITLE
Allow markdown content for alert message

### DIFF
--- a/_includes/alert-message.html
+++ b/_includes/alert-message.html
@@ -10,7 +10,7 @@ Alert: We have become aware of an issue with the accuracy of data for this page 
       </div>
     </div>
     <div class="alert-message__content">
-      {{ include.message | default: default_message }}
+      {{ include.message | default: default_message | markdownify }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #151 

This allows folks to include links to FAQs and other things in the alert
messaging.

I added messaging to [Aimee Eng and Desley Brooks](https://docs.google.com/spreadsheets/d/1vJR8GR5Bk3bUQXziPiQe7to1O-QEm-_5GfD7hPjp-Xc/edit#gid=0) in the spreadsheet. 
![screenshot from 2018-07-24 19-35-38](https://user-images.githubusercontent.com/509703/43176530-ef65d0d8-8f78-11e8-9538-35dfa98af88c.png)
