### PR TITLE
www.opendisclosure.io

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.opendisclosure.io

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Being a collaboration of brigades, we often meetup in person at our local
 brigades without the entire group. It's important to keep the rest of the group
 informed. We can't all make it to four brigade meetings a week `;-)` Keep this
 in mind as you collaborate and consider posting decisions or learnings to our
-[slack](https://opencal.slack.com) or comment on an [issue](/issues).
+[slack](https://caciviclab.slack.com) or comment on an [issue](/issues).
 
 
 ## Pull requests

--- a/_bin/deploy.sh
+++ b/_bin/deploy.sh
@@ -11,7 +11,7 @@ cd _site
 git --version
 git init
 git config user.name "CA Civic Lab deploy script"
-git config user.email "opencal@googlegroups.com"
+git config user.email "caciviclab+deploy@googlegroups.com"
 git add .
 git commit -m "Deploy to GitHub Pages"
 git push --force --quiet "git@github.com:${GITHUB_REPO}.git" master:gh-pages &> /dev/null || ( exit_code=$?; echo Error deploying to GH Pages: exit $exit_code >&2; exit $exit_code )

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: 'Open Disclosure California'
-email: your-email@example.com
+email: caciviclab@googlegroups.com
 description: >- # this means to ignore newlines until "baseurl:"
   We provide transparent, non-partisan campaign contribution and expenditure
   data in an accessible and easy to understand format. We hope this site will

--- a/_config.yml
+++ b/_config.yml
@@ -21,8 +21,8 @@ description: >- # this means to ignore newlines until "baseurl:"
   engage the voting public and raise awareness and accountability. Ultimately,
   this is one step toward shifting politics into a movement of civic engagement
   and ultimate citizen action.
-baseurl: "/odca-jekyll" # the subpath of your site, e.g. /blog
-url: "https://caciviclab.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "https://www.opendisclosure.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: caciviclab
 github_username:  caciviclab
 future: true

--- a/faq.md
+++ b/faq.md
@@ -83,7 +83,7 @@ Open Disclosure contains links to various third party websites that contain addi
 
 ## Who do I contact if I believe any of the data is incorrect?
 
-Contact the [Open Disclosure team](https://github.com/caciviclab/disclosure-frontend/issues/new?labels=type%2Fquestion&title=Feedback%3A+a+question+on+data+correctness) if you believe any of the data or candidate information is incorrect or violates the statement of impartiality outlined in the answer above. We want public feedback and ask to be notified if any errors are present. Thank you!
+Contact the [Open Disclosure team](https://github.com/caciviclab/odca-jekyll/issues/new?labels=type%2Fquestion&title=Feedback%3A+a+question+on+data+correctness) if you believe any of the data or candidate information is incorrect or violates the statement of impartiality outlined in the answer above. We want public feedback and ask to be notified if any errors are present. Thank you!
 
 ## What are Oakland's Campaign Finance Rules?
 


### PR DESCRIPTION
This configures the site to serve at www.opendisclosure.io. Fixes #168 

- [x] depends on https://github.com/caciviclab/disclosure-frontend/pull/257