### PR TITLE
Fix referendum expenditures

### DIFF
--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -1,5 +1,12 @@
+{% comment %}
+First we calculate the maximum for the money bar.
+{% endcomment %}
+{% assign max = 0 %}
+{% for committee in include.committees %}
+  {% assign max = max | plus: committee.amount %}
+{% endfor %}
 {% for committee in include.committees %}
   <div><a href="{{ site.baseurl }}/committee/{{ committee.id }}/">{{ committee.name }}</a></div>
   <div>{{ committee.amount | dollars }}</div>
-  {% include money-bar.html value=committee.amount color=include.color max=committee.amount %}
+  {% include money-bar.html value=committee.amount color=include.color max=max %}
 {% endfor %}

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -76,7 +76,7 @@ layout: default
 <!-- supporting contributions/expenditures column -->
 <section class="l-section">
   <div class="l-section__content">
-    <h2>Committee expenditures</h2>
+    <h2>Expenditures</h2>
   </div>
   <div class="l-section__content l-section__content--half">
     <div class="subheading">In support of the measure</div>


### PR DESCRIPTION
- Show "Expenditures" because some of the items are Major Donors and not
committees.
- Calculate the money bar max so they are relative to each other.


From this...
![screenshot from 2018-08-14 19-51-15](https://user-images.githubusercontent.com/509703/44129241-3886ffce-9ffc-11e8-88b9-bb6d4bceb76b.png)

To this...
![screenshot from 2018-08-14 19-57-41](https://user-images.githubusercontent.com/509703/44129277-58b49b26-9ffc-11e8-928d-4a6ab50de5ff.png)
