### PR TITLE
Add ImageMagick to prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 - [Bundler](https://bundler.io/) gem
 - [Make](https://www.gnu.org/software/make/)
 - [Node 8.9+](https://nodejs.org/)
+- [ImageMagick](https://www.imagemagick.org/)
 
 
 ## Setup


### PR DESCRIPTION
We use mini_magick which depends on ImageMagick. This is not ideal since it's an
annoying dependency to require and it's really only for the production build.