### PR TITLE
Include note about loans in contribution totals

### DIFF
--- a/_layouts/committee.html
+++ b/_layouts/committee.html
@@ -18,9 +18,17 @@ layout: default
       <span class="money">{{ finance.total_contributions | dollars }}</span>
     </div>
     {% if contributions == empty %}
-      <p>Sorry, there is no contribution data available for this committee.</p>
+      <p>
+        Sorry, there is no contribution data available for this committee. Note
+        that contributor tables do not presently include loans, although funds
+        from loans are included in the total contributions received.
+      </p>
     {% else %}
-    <contributions-table contributions="{{ contributions | jsonify | escape }}"></contributions-table>
+      <p class="note">
+        Contributor tables do not presently include loans, although funds
+        from loans are included in the total contributions received.
+      </p>
+      <contributions-table contributions="{{ contributions | jsonify | escape }}"></contributions-table>
     {% endif %}
   </div>
 </article>

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -100,3 +100,9 @@ a {
   margin-bottom: $spacing-base;
   margin-top: $spacing-base;
 }
+
+.note {
+  color: $subheading-color;
+  font-size: $small-font-size;
+  font-style: italic;
+}


### PR DESCRIPTION
This work resolves #212

Includes a note about loans in the contributions so that when the total is non-zero but no contributions are listed, there is an explanation why.


<!-- you may remove this section below if the PR does not include any visual changes -->
### Previews

With contributions:
![screenshot from 2018-09-09 23-18-35](https://user-images.githubusercontent.com/509703/45280180-3efb2b00-b488-11e8-85e0-c48ddde05553.png)

Without contributions:
![screenshot from 2018-09-09 23-19-54](https://user-images.githubusercontent.com/509703/45280192-49b5c000-b488-11e8-82c2-836e2140620e.png)

