### PR TITLE
Fix floats in election header

### DIFF
--- a/_sass/module/_election-header.scss
+++ b/_sass/module/_election-header.scss
@@ -1,13 +1,21 @@
 .election-header__updated-at {
-  float: right;
   font-size: $small-font-size;
 }
 
 .election-header__day {
-  float: left;
   color: $color-navy;
   font-size: $h3-font-size;
   font-weight: bold;
+}
+
+@include grid-media($neat-grid--medium) {
+  .election-header__updated-at {
+    float: right;
+  }
+
+  .election-header__day {
+    float: left;
+  }
 }
 
 .election-header__title {


### PR DESCRIPTION
On small screens, the updated-at and election date collide. Update the media
queries so they are only floating on medium+ screens.

### Bug
![screenshot from 2018-09-11 20-59-31](https://user-images.githubusercontent.com/509703/45401554-f8333f80-b605-11e8-90e3-43b3c8400219.png)

### Fix
![screenshot from 2018-09-11 21-00-27](https://user-images.githubusercontent.com/509703/45401561-02edd480-b606-11e8-8b86-d3d67dedc4ed.png)
