### PR TITLE
Uncramped candidate description area above social network links.

### DIFF
--- a/_sass/module/_candidate.scss
+++ b/_sass/module/_candidate.scss
@@ -12,6 +12,7 @@ $candidate-photo-width: 10rem;
   color: $subheading-color;
   font-style: italic;
   font-size: $h6-font-size;
+  margin-bottom: $spacing-base;
 }
 
 .candidate__info-container {


### PR DESCRIPTION
This work resolves #233.

Uncramped space below description or candidate.