### PR TITLE
show independent expenditures when a candidate has no contributions

### DIFF
--- a/_includes/candidate/finance.html
+++ b/_includes/candidate/finance.html
@@ -14,7 +14,13 @@
     {% endif %}
     <div class="candidate__summary candidate__summary--balance">Current balance: <span class="money">{{ finance.total_contributions | minus: finance.total_expenditures | minus: finance.total_loans_received | dollars }}</span></div>
     {% else %}
-    <div class="candidate__summary">No contributions have been reported for this candidate</div>
+    <div class="candidate__summary">No contributions have been reported for this candidate
+      <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
+        alt="Voluntary spending limits - more information" />
+        <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
+          <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
+      </span>
+    </div>
     {% endif %}
   </div>
 </section>

--- a/_includes/candidate/finance.html
+++ b/_includes/candidate/finance.html
@@ -6,12 +6,16 @@
     {% if candidate.data_warning %}
       {% include alert-message.html message=candidate.data_warning %}
     {% endif %}
+    {% if finance.total_contributions > 0 or finance.total_expenditures > 0 %}
     <div class="candidate__summary candidate__summary--contributions">Contributions: <span class="money">{{ finance.total_contributions | dollars }}</span></div>
     <div class="candidate__summary candidate__summary--expenditures">Expenditures: <span class="money">{{ finance.total_expenditures | dollars }}</span></div>
     {% if finance.total_loans_received > 0 %}
     <div class="candidate__summary candidate__summary--loans">Loans: <span class="money">{{ finance.total_loans_received | dollars }}</span></div>
     {% endif %}
     <div class="candidate__summary candidate__summary--balance">Current balance: <span class="money">{{ finance.total_contributions | minus: finance.total_expenditures | minus: finance.total_loans_received | dollars }}</span></div>
+    {% else %}
+    <div class="candidate__summary">No contributions have been reported for this candidate</div>
+    {% endif %}
   </div>
 </section>
 {% assign expenditures_against = finance.opposing_money.opposing_expenditures %}
@@ -32,6 +36,7 @@
   </div>
 </section>
 {% endif %}
+{% if finance.total_contributions > 0 or finance.total_expenditures > 0 %}
 {% assign money_bar_max = finance.total_contributions | plus: finance.total_expenditures %}
 <section class="l-section">
   <div class="l-section__content l-section__content--half">
@@ -71,3 +76,4 @@
     {% endfor %}
   </div>
 </section>
+{% endif %}

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -3,7 +3,7 @@ layout: default
 ---
 {% assign candidate = page %}
 {% if candidate.filer_id != empty %}
-{% assign other_committees = site.committees | where:"candidate_controlled_id", candidate.filer_id %}
+  {% assign other_committees = site.committees | where:"candidate_controlled_id", candidate.filer_id %}
 {% endif %}
 {% assign ballot = site.ballots | where: "path", candidate.ballot | first %}
 {% assign locality = site.localities | where: "locality_id", ballot.locality | first %}
@@ -65,8 +65,8 @@ layout: default
         </div>
       </div>
     </section>
-    {% if finance.total_contributions > 0 or finance.total_expenditures > 0 %}
-    {% include candidate/finance.html candidate=candidate finance=finance %}
+    {% if finance.total_contributions > 0 or finance.total_expenditures > 0 or finance.supporting_money.total_supporting_independent > 0 %}
+      {% include candidate/finance.html candidate=candidate finance=finance %}
     {% else %}
     <section class="l-section">
       <div class="l-section__content">

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -42,7 +42,7 @@ layout: default
               This candidate has agreed to voluntary spending limits.
               The maximum contribution this candidate can accept is $800 from any individual, business entity,
               committee or other organization and $1,600 from a qualified broad-based committee.
-              <span class="hover-info-container"><img src="{{ "/assets/images/icon_more_info.png" | relative_url }}"
+              <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
                   alt="Voluntary spending limits - more information" />
                 <span class="hover-info">For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/services/boards-and-commissions-index/ethics/campaign-finance-rules-and-disclosure/information-for-candidates-and-campaign-committees/oakland-campaign-contribution-limits">
                     Public Ethics Commission Candidate Resources page</a>.</span>
@@ -65,7 +65,8 @@ layout: default
         </div>
       </div>
     </section>
-    {% if finance.total_contributions > 0 or finance.total_expenditures > 0 or finance.supporting_money.total_supporting_independent > 0 %}
+    {% if finance.total_contributions > 0 or finance.total_expenditures > 0
+      or finance.supporting_money.total_supporting_independent > 0 or finance.opposing_money.opposing_expenditures > 0 %}
       {% include candidate/finance.html candidate=candidate finance=finance %}
     {% else %}
     <section class="l-section">


### PR DESCRIPTION
This work resolves #221 and #242

Previously, if a candidate had no reported contributions but had independent expenditures then we were displaying "no data for candidate" instead of showing those independent expenditures.

This work adds if/else conditions to show independent expenditures even when candidate has no reported contributions, and displays a message, "no contributions have been reported," in such a case. 

Also added a tooltip briefly explaining independent expenditures, per request of @sfdoran #242 


### Previews

Large screens
![screen shot 2018-09-18 at 8 32 34 pm](https://user-images.githubusercontent.com/20404311/45729670-646fef00-bb82-11e8-9648-035dd0d35064.png)

and a tooltip!
![screen shot 2018-09-18 at 8 32 23 pm](https://user-images.githubusercontent.com/20404311/45729678-6e91ed80-bb82-11e8-8866-a38f848ae3d2.png)


Small screens
![screen shot 2018-09-18 at 8 37 23 pm](https://user-images.githubusercontent.com/20404311/45729768-e233fa80-bb82-11e8-8c56-1a018394115f.png)
