### PR TITLE
Include missing supporting/opposing committees

### DIFF
--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -5,8 +5,20 @@ First we calculate the maximum for the money bar.
 {% for committee in include.committees %}
   {% assign max = max | plus: committee.amount %}
 {% endfor %}
+
 {% for committee in include.committees %}
-  <div><a href="{{ site.baseurl }}/committee/{{ committee.id }}/">{{ committee.name }}</a></div>
-  <div>{{ committee.amount | dollars }}</div>
-  {% include money-bar.html value=committee.amount color=include.color max=max %}
+  {% comment %}
+  We're dealing with two different object shapes, a committee from collection, or
+  a committee from the referendum supporting/opposing organzation list. One has
+  `filer_id`, the other `id`.
+  {% endcomment %}
+  {% assign filer_id = committee.filer_id | default: committee.id %}
+
+  <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ committee.name }}</a></div>
+  {% if committee.amount > 0 %}
+    <div>{{ committee.amount | dollars }}</div>
+    {% include money-bar.html value=committee.amount color=include.color max=max %}
+  {% else %}
+    <div class="note">No expenditures have been reported by this committee</div>
+  {% endif %}
 {% endfor %}

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -10,6 +10,32 @@ layout: default
 {% assign ballot = site.ballots | where: 'path', ballot_path | first %}
 {% assign locality = site.localities | where: 'locality_id', ballot.locality | first %}
 
+{% comment %}
+https://github.com/caciviclab/odca-jekyll/issues/248
+The list of supporting/opposing organizations is based on expenditures. Here we
+add any committees that are known supporting/opposing this referendum even if
+they don't have reported expenditures. Be careful not to add duplicates.
+Beware: these objects are shaped differently (they have different properties).
+{% endcomment %}
+{% assign supporting_opposing_committees  = site.committees | where: 'election', election_day | where: 'referendum_number', referendum.number %}
+{% assign supporting_committees = supporting_opposing_committees | where: 'support_or_oppose', 'S' %}
+{% assign opposing_committees = supporting_opposing_committees | where: 'support_or_oppose', 'O' %}
+{% assign supporting_organizations = supporting.supporting_organizations %}
+{% for committee in supporting_committees %}
+  {% assign committee_exists = supporting.supporting_organizations | where: 'id', committee.filer_id | first %}
+  {% unless committee_exists %}
+    {% assign supporting_organizations = supporting_organizations | push: committee %}
+  {% endunless %}
+{% endfor %}
+{% assign opposing_organizations = opposing.opposing_organizations %}
+{% for committee in opposing_committees %}
+  {% assign committee_exists = opposing.opposing_organizations | where: 'id', committee.filer_id | first %}
+  {% unless committee_exists %}
+    {% assign opposing_organizations = opposing_organizations | push: committee %}
+  {% endunless %}
+{% endfor %}
+
+
 {% capture body %}
 <header>
   {% if referendum.number %}
@@ -77,17 +103,17 @@ layout: default
 <!-- supporting contributions/expenditures column -->
 <section class="l-section">
   <div class="l-section__content">
-    <h2>Spending Breakdown by Committee</h2>
+    <h2>Spending breakdown by committee</h2>
   </div>
   <div class="l-section__content l-section__content--half">
     <div class="subheading">In support of the measure</div>
-    {% include supporting_opposing_committees.html committees=supporting.supporting_organizations color="green" %}
+    {% include supporting_opposing_committees.html committees=supporting_organizations color="green" %}
   </div>
 
 <!-- opposing contributions/expenditures column -->
   <div class="l-section__content l-section__content--half">
     <div class="subheading">In opposition of the measure</div>
-    {% include supporting_opposing_committees.html committees=opposing.opposing_organizations color="red" %}
+    {% include supporting_opposing_committees.html committees=opposing_organizations color="red" %}
   </div>
 </section>
 {% else %}


### PR DESCRIPTION
We calculate the supporting/opposing committees based on expenditures. So if the
committee hasn't made any expenditures, they won't show up in the list. This can
be confusing when contributions have been made, but no expenditures. In that
case, the totals for contributions appear, but it's unclear to which committees
those contributions were made.

This work resolves #248.



<!-- you may remove this section below if the PR does not include any visual changes -->
### Previews

![screenshot from 2018-09-24 22-55-03](https://user-images.githubusercontent.com/509703/45995771-545a8280-c04e-11e8-8b78-2b32a298ec06.png)
