### PR TITLE
move padding, hover color to ballot-nav <a> and give it display:block

### DIFF
--- a/_sass/module/_ballot-nav.scss
+++ b/_sass/module/_ballot-nav.scss
@@ -24,11 +24,19 @@ $ballot-nav-border: 2px $color-grey-4-5 solid;
   }
 
   p {
-    padding: $spacing-base;
+    // padding: $spacing-base;
     margin: auto;
   }
 
   p:hover {
+  }
+
+  a {
+    display: block;
+    padding: $spacing-base;
+  }
+
+  a:hover {
     background-color: $color-gold;
   }
 }

--- a/_sass/module/_ballot-nav.scss
+++ b/_sass/module/_ballot-nav.scss
@@ -24,11 +24,7 @@ $ballot-nav-border: 2px $color-grey-4-5 solid;
   }
 
   p {
-    // padding: $spacing-base;
     margin: auto;
-  }
-
-  p:hover {
   }
 
   a {


### PR DESCRIPTION
This work resolves #247.

Make the whole yellow highlighted part clickable, rather than just the text, when you hover the mouse on a ballot nav item

### Previews

![img_5106](https://user-images.githubusercontent.com/20404311/46056473-a8746e00-c105-11e8-9a67-d87237ee8048.jpg)
