### PR TITLE
Update styling of ballot measure titles in sidebar 

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -11,7 +11,8 @@
           <h4>{% include referendum_measure_heading.html referendum_measure_display=locality.referendum_measure_display %}</h4>
           {% for ballot_item in referendums %}
               {% assign referendum = site.referendums | where: "path", ballot_item | first %}
-              <p><a href="{{ referendum.url | prepend: site.baseurl }}">{% if referendum.number %}{{ referendum.number }} {% endif %}{{ referendum.title | escape}}</a></p>
+              <p><a href="{{ referendum.url | prepend: site.baseurl }}">Measure {% if referendum.number %}{{ referendum.number }} {% endif %}
+                <span class="ballot-nav__measure-title">{{ referendum.title | escape}}</span></a></p>
           {% endfor %}
         </div>
       {% endif %}

--- a/_sass/module/_ballot-nav.scss
+++ b/_sass/module/_ballot-nav.scss
@@ -44,3 +44,10 @@ a {
     font-weight: lighter;
   }
 }
+
+.ballot-nav__measure-title {
+  display: block;
+  color: $subheading-color;
+  font-style: italic;
+  font-size: $small-font-size;
+}


### PR DESCRIPTION
This work resolves #235

Split ballot measure nav items into two separate lines, one for measure number and the other for title, and style each line per @elinaru's specification


### Previews
Big:
![screen shot 2018-10-02 at 9 05 22 pm](https://user-images.githubusercontent.com/20404311/46389568-7922ab80-c687-11e8-92a2-628090b06420.png)

Small:
<img width="300" src="https://user-images.githubusercontent.com/20404311/46389598-b2f3b200-c687-11e8-8b31-442dcbddc0e4.png" />