### PR TITLE
Indent SUMMARY and TEXT

### DIFF
--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -47,13 +47,15 @@ Beware: these objects are shaped differently (they have different properties).
   {% endif %}
 </header>
 <section class="l-section referendum__summary">
-  {% if referendum.data_warning %}
-    {% include alert-message.html message=referendum.data_warning %}
-  {% endif %}
-  {% if referendum.content %}
-    <h3>Summary</h3>
-    {{ referendum.content }}
-  {% endif %}
+  <div class="l-section__content">
+    {% if referendum.data_warning %}
+      {% include alert-message.html message=referendum.data_warning %}
+    {% endif %}
+    {% if referendum.content %}
+      <h3>Summary</h3>
+      {{ referendum.content }}
+    {% endif %}
+</div>
 </section>
 
 {% if supporting.total_contributions > 0 or opposing.total_contributions > 0 %}

--- a/_sass/module/_referendum.scss
+++ b/_sass/module/_referendum.scss
@@ -18,10 +18,14 @@
 }
 
 .referendum__summary {
+  .l-section__content {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
   h3 {
     font-weight: $font-weight-normal;
     color: $color-grey-2;
-    text-transform: uppercase;
     padding-top: $spacing-base;
   }
 


### PR DESCRIPTION
This work resolves #268 .

Implemented new idnentation for the summary heading, heading text and by-line for referendums. Added a DIV with existing class around content. Removed extra padding on top and bottom for when this DIV is inside the '.referendum__summary' SECTION tag.
