### PR TITLE
add funds from public financing to candidate page and extract tooltip…

### DIFF
--- a/_includes/candidate/finance.html
+++ b/_includes/candidate/finance.html
@@ -10,12 +10,11 @@
     <div class="candidate__summary candidate__summary--contributions">Contributions: <span class="money">{{ finance.total_contributions | dollars }}</span></div>
     {% if candidate.public_funding_received %}
     <div class="candidate__summary candidate__summary--public-financing">
-      Funds From Public Financing:
-      {% capture tooltip_message %}
-      For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/resources/oakland-campaign-contribution-limits">
-      Public Ethics Commission Candidate Resources page</a>.
-      {% endcapture %}
-      {% include tooltip.html message=tooltip_message alt="Funds from Public Financing - more information" %}
+      Public financing received:
+      {% capture tooltip_message -%}
+      Eligible City Council candidates may apply for public funds to reimburse certain campaign expenses. Learn more from the <a href="https://www.oaklandca.gov/topics/limited-public-financing-program" target="_blank">Public Ethics Commission's Public Financing Program</a>.
+      {%- endcapture %}
+      {% include tooltip.html message=tooltip_message %}
       <span class="money">{{ candidate.public_funding_received | dollars }}</span>
     </div>
     {% endif %}
@@ -37,22 +36,22 @@
     {% if expenditures_against > 0 %}
     <div class="candidate__expenditures">
       Independent Expenditures Opposing Candidate <span class="money">{{ expenditures_against | dollars }}</span>
-      {% capture tooltip_message %}
+      {% capture tooltip_message -%}
       Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-      <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.
-      {% endcapture %}
-      {% include tooltip.html message=tooltip_message alt="Independent expenditures - more information" %}
+      <a href="{{ site.baseurl }}/faq/" target="_blank">see the FAQ </a>.
+      {%- endcapture %}
+      {% include tooltip.html message=tooltip_message %}
     </div>
     {% endif %}
     {% if independent_expenditures_for > 0 %}
     <div class="candidate__expenditures">
       Independent Expenditures Supporting Candidate <span class="money">{{ independent_expenditures_for | dollars }}</span>
       {% if expenditures_against <= 0 %}
-      {% capture tooltip_message %}
+      {% capture tooltip_message -%}
       Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-      <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.
-      {% endcapture %}
-      {% include tooltip.html message=tooltip_message alt="Independent expenditures - more information" %}
+      <a href="{{ site.baseurl }}/faq/" target="_blank">see the FAQ </a>.
+      {%- endcapture %}
+      {% include tooltip.html message=tooltip_message %}
       {% endif %}
     </div>
     {% endif %}

--- a/_includes/candidate/finance.html
+++ b/_includes/candidate/finance.html
@@ -8,6 +8,17 @@
     {% endif %}
     {% if finance.total_contributions > 0 or finance.total_expenditures > 0 %}
     <div class="candidate__summary candidate__summary--contributions">Contributions: <span class="money">{{ finance.total_contributions | dollars }}</span></div>
+    {% if candidate.public_funding_received %}
+    <div class="candidate__summary candidate__summary--public-financing">
+      Funds From Public Financing:
+      {% capture tooltip_message %}
+      For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/resources/oakland-campaign-contribution-limits">
+      Public Ethics Commission Candidate Resources page</a>.
+      {% endcapture %}
+      {% include tooltip.html message=tooltip_message alt="Funds from Public Financing - more information" %}
+      <span class="money">{{ candidate.public_funding_received | dollars }}</span>
+    </div>
+    {% endif %}
     <div class="candidate__summary candidate__summary--expenditures">Expenditures: <span class="money">{{ finance.total_expenditures | dollars }}</span></div>
     {% if finance.total_loans_received > 0 %}
     <div class="candidate__summary candidate__summary--loans">Loans: <span class="money">{{ finance.total_loans_received | dollars }}</span></div>
@@ -26,22 +37,22 @@
     {% if expenditures_against > 0 %}
     <div class="candidate__expenditures">
       Independent Expenditures Opposing Candidate <span class="money">{{ expenditures_against | dollars }}</span>
-      <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-        alt="Independent expenditures - more information" />
-        <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-          <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
-      </span>
+      {% capture tooltip_message %}
+      Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
+      <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.
+      {% endcapture %}
+      {% include tooltip.html message=tooltip_message alt="Independent expenditures - more information" %}
     </div>
     {% endif %}
     {% if independent_expenditures_for > 0 %}
     <div class="candidate__expenditures">
       Independent Expenditures Supporting Candidate <span class="money">{{ independent_expenditures_for | dollars }}</span>
       {% if expenditures_against <= 0 %}
-      <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-        alt="Independent expenditures - more information" />
-        <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-          <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
-      </span>
+      {% capture tooltip_message %}
+      Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
+      <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.
+      {% endcapture %}
+      {% include tooltip.html message=tooltip_message alt="Independent expenditures - more information" %}
       {% endif %}
     </div>
     {% endif %}

--- a/_includes/tooltip.html
+++ b/_includes/tooltip.html
@@ -1,0 +1,7 @@
+{% assign message = include.message %}
+{% assign alt = include.alt %}
+
+<span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
+    alt="{{ alt }}" />
+    <span class="hover-info">{{ message }}</span>
+</span>

--- a/_includes/tooltip.html
+++ b/_includes/tooltip.html
@@ -1,7 +1,6 @@
 {% assign message = include.message %}
-{% assign alt = include.alt %}
 
 <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-    alt="{{ alt }}" />
-    <span class="hover-info">{{ message }}</span>
+    alt="A question mark in circle indicating additional information" />
+    <span class="hover-info">{{ message | markdownify }}</span>
 </span>

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -42,11 +42,11 @@ layout: default
               This candidate has agreed to voluntary spending limits.
               The maximum contribution this candidate can accept is $800 from any individual, business entity,
               committee or other organization and $1,600 from a qualified broad-based committee.
-              <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-                  alt="Voluntary spending limits - more information" />
-                  <span class="hover-info">For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/resources/oakland-campaign-contribution-limits">
-                    Public Ethics Commission Candidate Resources page</a>.</span>
-              </span>
+              {% capture tooltip_message %}
+              For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/resources/oakland-campaign-contribution-limits">
+              Public Ethics Commission Candidate Resources page</a>.
+              {% endcapture %}
+              {% include tooltip.html message=tooltip_message alt="Voluntary spending limits - more information" %}
             </div>
             {% endif %}
             {% if candidate.website_url %}

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -42,11 +42,11 @@ layout: default
               This candidate has agreed to voluntary spending limits.
               The maximum contribution this candidate can accept is $800 from any individual, business entity,
               committee or other organization and $1,600 from a qualified broad-based committee.
-              {% capture tooltip_message %}
-              For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/resources/oakland-campaign-contribution-limits">
+              {% capture tooltip_message -%}
+              For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/resources/oakland-campaign-contribution-limits" target="_blank">
               Public Ethics Commission Candidate Resources page</a>.
-              {% endcapture %}
-              {% include tooltip.html message=tooltip_message alt="Voluntary spending limits - more information" %}
+              {%- endcapture %}
+              {% include tooltip.html message=tooltip_message %}
             </div>
             {% endif %}
             {% if candidate.website_url %}

--- a/_sass/module/_candidate.scss
+++ b/_sass/module/_candidate.scss
@@ -61,7 +61,8 @@ $candidate-photo-width: 10rem;
   }
 }
 
-.candidate__summary--contributions, .candidate__summary--public-financing {
+.candidate__summary--contributions,
+.candidate__summary--public-financing {
   color: $color-evergreen;
 
   .money {

--- a/_sass/module/_candidate.scss
+++ b/_sass/module/_candidate.scss
@@ -61,7 +61,7 @@ $candidate-photo-width: 10rem;
   }
 }
 
-.candidate__summary--contributions {
+.candidate__summary--contributions, .candidate__summary--public-financing {
   color: $color-evergreen;
 
   .money {

--- a/_sass/module/_hover-info.scss
+++ b/_sass/module/_hover-info.scss
@@ -19,6 +19,9 @@
   display: inline-block;
   height: 2.25rem;
   width: 4rem;
+  p {
+    margin: 0px;
+  }
 }
 
 .hover-info-container:hover .hover-info {

--- a/_sass/module/_hover-info.scss
+++ b/_sass/module/_hover-info.scss
@@ -19,8 +19,9 @@
   display: inline-block;
   height: 2.25rem;
   width: 4rem;
+
   p {
-    margin: 0px;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
… to its own file

This work resolves #261.

Made it so that the public finance field doesn't show up at all on candidate pages where we don't have the data, but I could also keep the label there and just show nothing where the number would be or some sort of placeholder like '--' or 'N/A'


<!-- you may remove this section below if the PR does not include any visual changes -->
### Previews

<img width="976" alt="screen shot 2018-10-11 at 11 00 54 am" src="https://user-images.githubusercontent.com/43800769/46826502-f961a480-cd4a-11e8-97a6-cb29717d6ba9.png">
