### PR TITLE
add spending breakdown by independent exp. committees on candidate pages

### DIFF
--- a/_includes/candidate/finance.html
+++ b/_includes/candidate/finance.html
@@ -25,7 +25,7 @@
   <div class="l-section__content">
     {% if expenditures_against > 0 %}
     <div class="candidate__expenditures">
-      Independent Expenditures Opposing Candidate <span class="money">{{ expenditures_against | dollars }}</span>
+      Independent expenditures opposing candidate <span class="money">{{ expenditures_against | dollars }}</span>
       <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
         alt="Independent expenditures - more information" />
         <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
@@ -35,7 +35,7 @@
     {% endif %}
     {% if independent_expenditures_for > 0 %}
     <div class="candidate__expenditures">
-      Independent Expenditures Supporting Candidate <span class="money">{{ independent_expenditures_for | dollars }}</span>
+      Independent expenditures supporting candidate <span class="money">{{ independent_expenditures_for | dollars }}</span>
       {% if expenditures_against <= 0 %}
       <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
         alt="Independent expenditures - more information" />

--- a/_includes/candidate/finance.html
+++ b/_includes/candidate/finance.html
@@ -18,36 +18,6 @@
     {% endif %}
   </div>
 </section>
-{% assign expenditures_against = finance.opposing_money.opposing_expenditures %}
-{% assign independent_expenditures_for = finance.supporting_money.total_supporting_independent %}
-{% if expenditures_against > 0 or independent_expenditures_for > 0 %}
-<section class="l-section">
-  <div class="l-section__content">
-    {% if expenditures_against > 0 %}
-    <div class="candidate__expenditures">
-      Independent expenditures opposing candidate <span class="money">{{ expenditures_against | dollars }}</span>
-      <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-        alt="Independent expenditures - more information" />
-        <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-          <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
-      </span>
-    </div>
-    {% endif %}
-    {% if independent_expenditures_for > 0 %}
-    <div class="candidate__expenditures">
-      Independent expenditures supporting candidate <span class="money">{{ independent_expenditures_for | dollars }}</span>
-      {% if expenditures_against <= 0 %}
-      <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-        alt="Independent expenditures - more information" />
-        <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-          <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
-      </span>
-      {% endif %}
-    </div>
-    {% endif %}
-  </div>
-</section>
-{% endif %}
 {% if finance.total_contributions > 0 or finance.total_expenditures > 0 %}
 {% assign money_bar_max = finance.total_contributions | plus: finance.total_expenditures %}
 <section class="l-section">

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -1,23 +1,54 @@
 {% comment %}
+data:
+  committees = [
+    {
+      amount
+      filer_id || id
+      name
+    }
+  ]
+{% endcomment %}
+
+{% comment %}
 First we calculate the maximum for the money bar.
 {% endcomment %}
 {% assign max = 0 %}
 {% for committee in include.committees %}
-  {% assign max = max | plus: committee.amount %}
+  {% assign amount = committee.Total | default: committee.amount %}
+  {% assign max = max | plus: amount %}
 {% endfor %}
 
 {% for committee in include.committees %}
   {% comment %}
-  We're dealing with two different object shapes, a committee from collection, or
-  a committee from the referendum supporting/opposing organzation list. One has
-  `filer_id`, the other `id`.
+  We're dealing with three different object shapes
+    1. a committee from collection
+    and one of the following:
+    2. a committee from the referendum supporting/opposing organization list.
+    3. a committee from the candidate support_list/opposition_list organization list
+  committee collection has:
+    `filer_id`
+  referendum support/oppose org list has:
+    the other `id`
+  candidate support/oppose org list has:
+    `Filer_ID`
+    `Total`
+    `Filer_NamL`
   {% endcomment %}
-  {% assign filer_id = committee.filer_id | default: committee.id %}
 
-  <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ committee.name }}</a></div>
-  {% if committee.amount > 0 %}
-    <div>{{ committee.amount | dollars }}</div>
-    {% include money-bar.html value=committee.amount color=include.color max=max %}
+  {% if committee.filer_id %}
+    {% assign filer_id = committee.filer_id %}
+  {% else if committee.id %}
+    {% assign filer_id = committee.id %}
+  {% else committee.Filer_ID %}
+    {% assign filer_id = committee.Filer_ID %}
+  {% endif %}
+  {% assign money = committee.Total | default: committee.amount %}
+  {% assign name = committee.Filer_NamL | committee.name %}
+
+  <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ name }}</a></div>
+  {% if money > 0 %}
+    <div>{{ money | dollars }}</div>
+    {% include money-bar.html value=money color=include.color max=max %}
   {% else %}
     <div class="note">No expenditures have been reported by this committee</div>
   {% endif %}

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -35,14 +35,12 @@ First we calculate the maximum for the money bar.
     `Filer_NamL`
   {% endcomment %}
 
-  {% if committee.filer_id %}
-    {% assign filer_id = "committee.filer_id" %}
-  {% elsif committee.id %}
-    {% assign filer_id = "committee.id" %}
+  {% if committee.id %}
+    {% assign filer_id = committee.id %}
   {% elsif committee.Filer_ID %}
     {% assign filer_id = committee.Filer_ID %}
   {% else %}
-    {% assign filer_id = "foo_bar" %}
+    {% assign filer_id = committee.filer_id %}
   {% endif %}
   {% assign money = committee.Total | default: committee.amount %}
   {% assign name = committee.Filer_NamL | default: committee.name %}

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -43,9 +43,9 @@ First we calculate the maximum for the money bar.
     {% assign filer_id = committee.Filer_ID %}
   {% endif %}
   {% assign money = committee.Total | default: committee.amount %}
-  {% assign name = committee.Filer_NamL | committee.name %}
+  {% assign name = committee.Filer_NamL | default: committee.name %}
 
-  <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ name }}</a></div>
+  <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ name | smartify | escape }}</a></div>
   {% if money > 0 %}
     <div>{{ money | dollars }}</div>
     {% include money-bar.html value=money color=include.color max=max %}

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -36,11 +36,13 @@ First we calculate the maximum for the money bar.
   {% endcomment %}
 
   {% if committee.filer_id %}
-    {% assign filer_id = committee.filer_id %}
-  {% else if committee.id %}
-    {% assign filer_id = committee.id %}
-  {% else committee.Filer_ID %}
+    {% assign filer_id = "committee.filer_id" %}
+  {% elsif committee.id %}
+    {% assign filer_id = "committee.id" %}
+  {% elsif committee.Filer_ID %}
     {% assign filer_id = committee.Filer_ID %}
+  {% else %}
+    {% assign filer_id = "foo_bar" %}
   {% endif %}
   {% assign money = committee.Total | default: committee.amount %}
   {% assign name = committee.Filer_NamL | default: committee.name %}

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -42,14 +42,17 @@ First we calculate the maximum for the money bar.
   {% else %}
     {% assign filer_id = committee.filer_id %}
   {% endif %}
+  {% assign filer_id = filer_id | downcase %}
   {% assign money = committee.Total | default: committee.amount %}
   {% assign name = committee.Filer_NamL | default: committee.name %}
 
+  {% if filer_id != "pending" %}
   <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ name | smartify | escape }}</a></div>
   {% if money > 0 %}
     <div>{{ money | dollars }}</div>
     {% include money-bar.html value=money color=include.color max=max %}
   {% else %}
     <div class="note">No expenditures have been reported by this committee</div>
+  {% endif %}
   {% endif %}
 {% endfor %}

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -42,11 +42,10 @@ First we calculate the maximum for the money bar.
   {% else %}
     {% assign filer_id = committee.filer_id %}
   {% endif %}
-  {% assign filer_id = filer_id | downcase %}
   {% assign money = committee.Total | default: committee.amount %}
   {% assign name = committee.Filer_NamL | default: committee.name %}
 
-  {% if filer_id != "pending" %}
+  {% if filer_id != "pending" and filer_id != "Pending" and filer_id != "PENDING" %}
   <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ name | smartify | escape }}</a></div>
   {% if money > 0 %}
     <div>{{ money | dollars }}</div>

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -1,5 +1,5 @@
 {% comment %}
-data:
+committee data expected this shape:
   committees = [
     {
       amount
@@ -21,14 +21,14 @@ First we calculate the maximum for the money bar.
 {% for committee in include.committees %}
   {% comment %}
   We're dealing with three different object shapes
-    1. a committee from collection
+    1. a committee from committees collection
     and one of the following:
     2. a committee from the referendum supporting/opposing organization list.
     3. a committee from the candidate support_list/opposition_list organization list
   committee collection has:
     `filer_id`
   referendum support/oppose org list has:
-    the other `id`
+    `id`
   candidate support/oppose org list has:
     `Filer_ID`
     `Total`

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -98,55 +98,13 @@ layout: default
       <!-- supporting contributions/expenditures column -->
         <div class="subheading">In support of the candidate</div>
         
-        {% comment %}
-          This loop is mostly cribbed from _includes/supporting_opposing_committees.html
-          Ideally we would use that include here
-            but the objects are shaped differently (they have different properties)
-        {% endcomment %}
-
-        {% for committee in supporting_committees %}
-
-        {% assign filer_id = site.committees.filer_id | where: "name", committee.Filer_NamL %}
-
-        <div><a href="{{ site.baseurl }}/committee/{{ committee.Filer_ID }}/">{{ committee.Filer_NamL }}</a></div>
-        {% if committee.Total > 0 %}
-        <div>{{ committee.Total | dollars }}</div>
-
-        {% comment %}
-          The money-bar takes an object of a different shape than finance.supporting_money.support_list
-          This will need some work to work properly with the candidate data
-        {% endcomment %}
-        {% include money-bar.html value=committee.Total color=include.color max=max %}
-        {% else %}
-        <div class="note">No expenditures have been reported by this committee</div>
-        {% endif %}
-        {% endfor %}
-
-      </div>
+        {% include supporting_opposing_committees.html committees=supporting_committees color="green" %}
 
     <!-- opposing contributions/expenditures column -->
       <div class="l-section__content l-section__content--half">
         <div class="subheading">In opposition of the candidate</div>
 
-        {% comment %}
-          see above comment about _inclues/suppporting_opposing_committees
-        {% endcomment %}
-        
-        {% for committee in opposing_committees %}
-
-        <div><a href="{{ site.baseurl }}/committee/{{ committee.Filer_ID }}/">{{ committee.Filer_NamL }}</a></div>
-        {% if committee.Total > 0 %}
-        <div>{{ committee.Total | dollars }}</div>
-
-        {% comment %}
-          The money-bar takes an object of a different shape than finance.supporting_money.support_list
-          This will need some work to work properly with the candidate data
-        {% endcomment %}
-        {% include money-bar.html value=committee.Total color=include.color max=max %}
-        {% else %}
-        <div class="note">No expenditures have been reported by this committee</div>
-        {% endif %}
-        {% endfor %}
+        {% include supporting_opposing_committees.html committees=opposing_committees color="red" %}
 
       </div>
     </section>

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -12,6 +12,8 @@ layout: default
 {% assign finance = site.data.candidates[locality.slug][election_day][candidate.slug] %}
 {% assign opposing_committees = finance.opposing_money.opposition_list %}
 {% assign supporting_committees = finance.supporting_money.support_list %}
+{% assign expenditures_opposing = finance.opposing_money.opposing_expenditures %}
+{% assign expenditures_supporting = finance.supporting_money.total_supporting_independent %}
 
 {% capture body %}
 <div class="candidate">
@@ -90,6 +92,34 @@ layout: default
       </div>
     </section>
     {% endif %}
+{% if expenditures_opposing > 0 or expenditures_supporting > 0 %}
+<section class="l-section">
+  <div class="l-section__content">
+    {% if expenditures_opposing > 0 %}
+    <div class="candidate__expenditures">
+      Independent expenditures opposing candidate <span class="money">{{ expenditures_opposing | dollars }}</span>
+      <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
+        alt="Independent expenditures - more information" />
+        <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
+          <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
+      </span>
+    </div>
+    {% endif %}
+    {% if expenditures_supporting > 0 %}
+    <div class="candidate__expenditures">
+      Independent expenditures supporting candidate <span class="money">{{ expenditures_supporting | dollars }}</span>
+      {% if expenditures_opposing <= 0 %}
+      <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
+        alt="Independent expenditures - more information" />
+        <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
+          <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
+      </span>
+      {% endif %}
+    </div>
+    {% endif %}
+  </div>
+</section>
+{% endif %}
     {% if supporting_committees != empty or opposing_committees != empty %}
     <section class="l-section">
       <div class="l-section__content">
@@ -100,7 +130,7 @@ layout: default
         <div class="subheading">In support of the candidate</div>
         {% include supporting_opposing_committees.html committees=supporting_committees color="green" %}
         </div>
-    <!-- opposing contributions/expenditures column -->
+      <!-- opposing contributions/expenditures column -->
       <div class="l-section__content l-section__content--half">
         <div class="subheading">In opposition of the candidate</div>
         {% include supporting_opposing_committees.html committees=opposing_committees color="red" %}

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -9,7 +9,8 @@ layout: default
 {% assign locality = site.localities | where: "locality_id", ballot.locality | first %}
 {% assign election_day = ballot.election | date: '%Y-%m-%d' %}
 {% assign finance = site.data.candidates[locality.slug][election_day][candidate.slug] %}
-
+{% assign opposing_committees = finance.opposing_money.opposition_list %}
+{% assign supporting_committees = finance.supporting_money.support_list %}
 
 {% capture body %}
 <div class="candidate">
@@ -88,6 +89,68 @@ layout: default
       </div>
     </section>
     {% endif %}
+
+    <section class="l-section">
+      <div class="l-section__content">
+        <h2>Spending breakdown by committee</h2>
+      </div>
+      <div class="l-section__content l-section__content--half">
+      <!-- supporting contributions/expenditures column -->
+        <div class="subheading">In support of the candidate</div>
+        
+        {% comment %}
+          This loop is mostly cribbed from _includes/supporting_opposing_committees.html
+          Ideally we would use that include here
+            but the objects are shaped differently (they have different properties)
+        {% endcomment %}
+
+        {% for committee in supporting_committees %}
+
+        {% assign filer_id = site.committees.filer_id | where: "name", committee.Filer_NamL %}
+
+        <div><a href="{{ site.baseurl }}/committee/{{ committee.Filer_ID }}/">{{ committee.Filer_NamL }}</a></div>
+        {% if committee.Total > 0 %}
+        <div>{{ committee.Total | dollars }}</div>
+
+        {% comment %}
+          The money-bar takes an object of a different shape than finance.supporting_money.support_list
+          This will need some work to work properly with the candidate data
+        {% endcomment %}
+        {% include money-bar.html value=committee.Total color=include.color max=max %}
+        {% else %}
+        <div class="note">No expenditures have been reported by this committee</div>
+        {% endif %}
+        {% endfor %}
+
+      </div>
+
+    <!-- opposing contributions/expenditures column -->
+      <div class="l-section__content l-section__content--half">
+        <div class="subheading">In opposition of the candidate</div>
+
+        {% comment %}
+          see above comment about _inclues/suppporting_opposing_committees
+        {% endcomment %}
+        
+        {% for committee in opposing_committees %}
+
+        <div><a href="{{ site.baseurl }}/committee/{{ committee.Filer_ID }}/">{{ committee.Filer_NamL }}</a></div>
+        {% if committee.Total > 0 %}
+        <div>{{ committee.Total | dollars }}</div>
+
+        {% comment %}
+          The money-bar takes an object of a different shape than finance.supporting_money.support_list
+          This will need some work to work properly with the candidate data
+        {% endcomment %}
+        {% include money-bar.html value=committee.Total color=include.color max=max %}
+        {% else %}
+        <div class="note">No expenditures have been reported by this committee</div>
+        {% endif %}
+        {% endfor %}
+
+      </div>
+    </section>
+
   </div>
 </div>
 {% endcapture %}

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -92,34 +92,34 @@ layout: default
       </div>
     </section>
     {% endif %}
-{% if expenditures_opposing > 0 or expenditures_supporting > 0 %}
-<section class="l-section">
-  <div class="l-section__content">
-    {% if expenditures_opposing > 0 %}
-    <div class="candidate__expenditures">
-      Independent expenditures opposing candidate <span class="money">{{ expenditures_opposing | dollars }}</span>
-      <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-        alt="Independent expenditures - more information" />
-        <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-          <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
-      </span>
-    </div>
+    {% if expenditures_opposing > 0 or expenditures_supporting > 0 %}
+    <section class="l-section">
+      <div class="l-section__content">
+        {% if expenditures_opposing > 0 %}
+        <div class="candidate__expenditures">
+          Independent expenditures opposing candidate <span class="money">{{ expenditures_opposing | dollars }}</span>
+          <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
+            alt="Independent expenditures - more information" />
+            <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
+              <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
+          </span>
+        </div>
+        {% endif %}
+        {% if expenditures_supporting > 0 %}
+        <div class="candidate__expenditures">
+          Independent expenditures supporting candidate <span class="money">{{ expenditures_supporting | dollars }}</span>
+          {% if expenditures_opposing <= 0 %}
+          <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
+            alt="Independent expenditures - more information" />
+            <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
+              <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
+          </span>
+          {% endif %}
+        </div>
+        {% endif %}
+      </div>
+    </section>
     {% endif %}
-    {% if expenditures_supporting > 0 %}
-    <div class="candidate__expenditures">
-      Independent expenditures supporting candidate <span class="money">{{ expenditures_supporting | dollars }}</span>
-      {% if expenditures_opposing <= 0 %}
-      <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-        alt="Independent expenditures - more information" />
-        <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-          <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
-      </span>
-      {% endif %}
-    </div>
-    {% endif %}
-  </div>
-</section>
-{% endif %}
     {% if supporting_committees != empty or opposing_committees != empty %}
     <section class="l-section">
       <div class="l-section__content">

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -93,27 +93,22 @@ layout: default
     </section>
     {% endif %}
     {% if expenditures_opposing > 0 or expenditures_supporting > 0 %}
+    {% capture tooltip_message -%}
+    Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more, <a href="{{ site.baseurl }}/faq/">see the FAQ</a>.
+    {%- endcapture %}
     <section class="l-section">
       <div class="l-section__content">
         {% if expenditures_opposing > 0 %}
         <div class="candidate__expenditures">
           Independent expenditures opposing candidate <span class="money">{{ expenditures_opposing | dollars }}</span>
-          <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-            alt="Independent expenditures - more information" />
-            <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-              <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
-          </span>
+          {% include tooltip.html message=tooltip_message %}
         </div>
         {% endif %}
         {% if expenditures_supporting > 0 %}
         <div class="candidate__expenditures">
           Independent expenditures supporting candidate <span class="money">{{ expenditures_supporting | dollars }}</span>
           {% if expenditures_opposing <= 0 %}
-          <span class="hover-info-container"><img src="{{ '/assets/images/icon_more_info.png' | relative_url }}"
-            alt="Independent expenditures - more information" />
-            <span class="hover-info">Spending by third parties that advocates the election or defeat of a candidate and is not made in coordination with a candidate or campaign committee is termed an independent expenditure. To learn more,
-              <a href="{{ site.baseurl }}/faq/">see the FAQ </a>.</span>
-          </span>
+          {% include tooltip.html message=tooltip_message %}
           {% endif %}
         </div>
         {% endif %}

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -90,7 +90,7 @@ layout: default
       </div>
     </section>
     {% endif %}
-
+    {% if supporting_committees != empty or opposing_committees != empty %}
     <section class="l-section">
       <div class="l-section__content">
         <h2>Spending breakdown by committee</h2>
@@ -98,20 +98,15 @@ layout: default
       <div class="l-section__content l-section__content--half">
       <!-- supporting contributions/expenditures column -->
         <div class="subheading">In support of the candidate</div>
-        
         {% include supporting_opposing_committees.html committees=supporting_committees color="green" %}
-
         </div>
-
     <!-- opposing contributions/expenditures column -->
       <div class="l-section__content l-section__content--half">
         <div class="subheading">In opposition of the candidate</div>
-
         {% include supporting_opposing_committees.html committees=opposing_committees color="red" %}
-
       </div>
     </section>
-
+    {% endif %}
   </div>
 </div>
 {% endcapture %}

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -100,6 +100,8 @@ layout: default
         
         {% include supporting_opposing_committees.html committees=supporting_committees color="green" %}
 
+        </div>
+
     <!-- opposing contributions/expenditures column -->
       <div class="l-section__content l-section__content--half">
         <div class="subheading">In opposition of the candidate</div>


### PR DESCRIPTION
This work resolves #231 .

Display supporting | opposing committees in two columns on candidate page.

This uses the same include that the referendum pages uses, `supporting_opposing_committees.html`. Because the data at `supporting_money.support_list` and `opposing_money.opposition_list` in candidate json comes in a different shape than the supporting and opposing committee data for a referendum, I added logic to `supporting_opposing_committees` to capture the money, name, and id values as they appear in the candidate json. I updated the comment in that file to reflect the changes.


### Previews

Large screens
![screen shot 2018-10-14 at 9 12 24 pm](https://user-images.githubusercontent.com/20404311/46929722-f0e0c680-cff5-11e8-95d3-e01821f52bfd.png)


Small screens
<img src="https://user-images.githubusercontent.com/20404311/46929725-f807d480-cff5-11e8-9a1b-5060b48eb8ab.png" width="300" alt="screen shot of independent expenditure committee spending breakdown as it appears on small screen" >