### PR TITLE
Puts 'tabindex' in sidebar <a> tags to fix keyboard-nav order

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -1,6 +1,7 @@
 {% assign locality = include.locality %}
 {% assign referendums = include.ballot.referendums %}
 {% assign office_elections = include.ballot.office_elections %}
+{% assign tabIndxVar = 4 %}
 
 <nav class="ballot-nav">
   <section class="l-section">
@@ -9,9 +10,10 @@
         <div class="ballot-nav__group">
           <h4>{% include referendum_measure_heading.html referendum_measure_display=locality.referendum_measure_display %}</h4>
           {% for ballot_item in referendums %}
+              {% assign tabIndxVar = tabIndxVar | plus:1 %}
               {% assign referendum = site.referendums | where: "path", ballot_item | first %}
               <p {% if page.url == referendum.url %}class="current-page"{% endif %}>
-                <a href="{{ referendum.url | prepend: site.baseurl }}">
+                <a href="{{ referendum.url | prepend: site.baseurl }}" tabindex="{{ tabIndxVar }}">
                   Measure {% if referendum.number %}{{ referendum.number }} {% endif %}
                   <span class="ballot-nav__measure-title">{{ referendum.title | escape}}</span>
                 </a>
@@ -21,14 +23,16 @@
       {% endif %}
       {% if office_elections and office_elections != empty %}
         {% for ballot_item in office_elections %}
+          {% assign tabIndxVar = tabIndxVar | plus:1 %}
           <div class="ballot-nav__group">
             {% if ballot_item.label %}
               <h4>{{ ballot_item.label | escape }}</h4>
             {% endif %}
             {% for office_election_path in ballot_item.items %}
+            {% assign tabIndxVar = tabIndxVar | plus:1 %}
               {% assign office_election = site.office_elections | where: "path", office_election_path | first %}
               <p {% if page.url == office_election.url %}class="current-page"{% endif %}>
-                <a href="{{ office_election.url | prepend: site.baseurl }}">{{ office_election.title }}</a>
+                <a href="{{ office_election.url | prepend: site.baseurl }}" tabindex="{{ tabIndxVar}}">{{ office_election.title }}</a>
               </p>
             {% endfor %}
           </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
   <div class="header__wrapper grid-col-12">
     {% assign default_paths = site.pages | map: "path" %}
     {% assign page_paths = site.header_pages | default: default_paths %}
-    <a class="header__title header__title--md" rel="author" href="{{ "/" | relative_url }}">Open Disclosure Oakland</a>
+    <a class="header__title header__title--md" rel="author" href="{{ "/" | relative_url }}" tabindex="1">Open Disclosure Oakland</a>
 
     {% if page_paths %}
       <nav class="header-nav">
@@ -18,8 +18,8 @@
           </span>
         </label>
         <div class="header-nav__items">
-          <a class="header-nav__link-item" href="{{ site.baseurl }}/about/">About</a>
-          <a class="header-nav__link-item" href="{{ site.baseurl }}/faq/">FAQ</a>
+          <a class="header-nav__link-item" href="{{ site.baseurl }}/about/" tabindex="2">About</a>
+          <a class="header-nav__link-item" href="{{ site.baseurl }}/faq/" tabindex="3">FAQ</a>
         </div>
       </nav>
       <a class="header__title" rel="author" href="{{ "/" | relative_url }}">ODOAK</a>


### PR DESCRIPTION
This work resolves #228 

Manually adds indexes 1,2,3 to header nav.
Adds a counter `tabIndxVar=4` to ballot-nav.html. In each for-loop, as sidebar's <a> are rendered, `tabIndex="{{ tabIndxVar }}"` is added to each link and counter is incremented.

Root cause is actually in ballot-layout.html where `<div class="l-ballot__nav">` comes *after* content `<div class="l-ballot__main">`.  <nav> should be before <content>

Note: `tabindex` is a non-ARIA/a11y compliant technique that is subject to deprecation.