### PR TITLE
add press page and links in header and footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,6 +6,7 @@
           <h2 class="footer__heading"><a class="brand" href="{{ site.baseurl }}/">Open<span class="brand__em">Disclosure</span><span class="brand__light"> Oakland</span></a></h2>
           <ul class="footer__nav">
             <li class="footer__nav-item"><a href="{{ site.baseurl }}/about/">About</a></li>
+            <li class="footer__nav-item"><a href="{{ site.baseurl }}/press/">Press</a></li>
             <li class="footer__nav-item"><a href="{{ site.baseurl }}/faq/">FAQ</a></li>
             <li class="footer__nav-item"><a href="https://caciviclab.org/opendisclosure/">Join us</a></li>
             <li class="footer__nav-item"><a href="https://github.com/caciviclab/odca-jekyll#license">Open source</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,6 +18,7 @@
           </span>
         </label>
         <div class="header-nav__items">
+          <a class="header-nav__link-item" href="{{ site.baseurl }}/press/">Press</a>
           <a class="header-nav__link-item" href="{{ site.baseurl }}/about/">About</a>
           <a class="header-nav__link-item" href="{{ site.baseurl }}/faq/">FAQ</a>
         </div>

--- a/_sass/_module.scss
+++ b/_sass/_module.scss
@@ -11,11 +11,12 @@
 @import 'module/header';
 @import 'module/header-nav';
 @import 'module/hero';
+@import 'module/hover-info';
 @import 'module/icon';
 @import 'module/landing-description';
 @import 'module/money';
 @import 'module/money-bar';
 @import 'module/office-election';
+@import 'module/page';
 @import 'module/referendum';
 @import 'module/tagline';
-@import 'module/hover-info';

--- a/_sass/module/_page.scss
+++ b/_sass/module/_page.scss
@@ -1,0 +1,3 @@
+.page__content {
+  margin-bottom: 2 * $spacing-base;
+}

--- a/press.md
+++ b/press.md
@@ -10,6 +10,9 @@ title: Press
 [Oakland Elections Fundraising News Thanks To Open Disclosure Oakland](http://oaklandnewsnow.com/index.php/2018/10/05/oakland-elections-fundraising-news-thanks-to-open-disclosure-oakland/)  
 *October 5, 2018 – Oakland News Now, Zennie Abraham*
 
+[Oakland Public Ethics Commission and Local Volunteers Launch Campaign Finance App for November Election](https://www.oaklandca.gov/news/2018/oakland-public-ethics-commission-and-local-volunteers-launch-campaign-finance-app-for-november-election)  
+*September 18, 2018 – City of Oakland*
+
 
 ## 2016
 
@@ -18,6 +21,9 @@ title: Press
 
 [OpenOakland and The Search for Sustainable Civic Technology](https://civichall.org/civicist/open-oakland-and-the-search-sustainable-civic-tech/)  
 *May 9, 2016 – Civicist/Civic Hall, Jessica McKenzie*
+
+[Local Volunteers Build OpenDisclosure.io Website to Show Political Campaign Contributions](https://www.oaklandca.gov/news/2016/local-volunteers-build-opendisclosure-io-website-to-show-political-campaign-contributions)
+*October 18, 2016 – City of Oakland*
 
 
 ## 2014

--- a/press.md
+++ b/press.md
@@ -1,0 +1,29 @@
+---
+title: Press
+---
+
+## 2018
+
+[Follow the money: Updated website makes Oakland election data accessible](https://oaklandnorth.net/2018/10/10/follow-the-money-updated-website-makes-oakland-election-data-accessible/)  
+*October 10, 2018 – Oakland North, Maria Sestito*
+
+[Oakland Elections Fundraising News Thanks To Open Disclosure Oakland](http://oaklandnewsnow.com/index.php/2018/10/05/oakland-elections-fundraising-news-thanks-to-open-disclosure-oakland/)  
+*October 5, 2018 – Oakland News Now, Zennie Abraham*
+
+
+## 2016
+
+[Oakland’s Code for America summit emphasizes diversity and inclusiveness](https://www.eastbaytimes.com/2016/11/16/oaklands-code-for-america-summit-emphasizes-diversity-and-inclusiveness/)  
+*November 16, 2016 – East Bay Times, Howard Dyckoff*
+
+[OpenOakland and The Search for Sustainable Civic Technology](https://civichall.org/civicist/open-oakland-and-the-search-sustainable-civic-tech/)  
+*May 9, 2016 – Civicist/Civic Hall, Jessica McKenzie*
+
+
+## 2014
+
+[Oakland App Sheds Light on Campaign Finance](http://www.govtech.com/data/Oakland-App-Sheds-Light-on-Campaign-Finance.html?utm_source=newsletter_editorial&utm_medium=saturday_edition&utm_campaign=GovTech_Today&elq=23c8f56ed8714e8cb6aa1fb314580d3f&elqCampaignId=10033)  
+*August 28, 2014 – Gov Tech, Jason Shueh*
+
+[Volunteers hack technology to improve Oakland city government](http://www.kalw.org/post/volunteers-hack-technology-improve-oakland-city-government#stream/0)  
+*March 18, 2014 – KALW Radio, Laura Flynn*


### PR DESCRIPTION
This work resolves #<256>.

Added a new markdown page for links to articles about (or that mention) Open Disclosure
Placed links in header and footer

### Previews

<img width="1440" alt="screen shot 2018-10-16 at 9 11 14 pm" src="https://user-images.githubusercontent.com/43800769/47061888-72685e00-d188-11e8-93cb-2ceffa0e33af.png">

<img width="1440" alt="screen shot 2018-10-16 at 9 11 26 pm" src="https://user-images.githubusercontent.com/43800769/47061895-77c5a880-d188-11e8-87b7-d789e58e076a.png">

