### PR TITLE
show supporting, opposing committees for measures where total_contributions = 0

### DIFF
--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -113,8 +113,8 @@ Beware: these objects are shaped differently (they have different properties).
 {% endif %}
 
 <!-- supporting contributions/expenditures column -->
-{% if supporting_organizations != empty or opposing_organizations != empty %}
 <section class="l-section">
+{% if supporting_organizations != empty or opposing_organizations != empty %}
   <div class="l-section__content">
     <h2>Spending breakdown by committee
     {% capture tooltip_message -%}
@@ -133,8 +133,12 @@ Beware: these objects are shaped differently (they have different properties).
     <div class="subheading">In opposition of the measure</div>
     {% include supporting_opposing_committees.html committees=opposing_organizations color="red" %}
   </div>
-</section>
+{% else %}
+  <div class="l-section__content">
+    <p><i>No independent expenditures have been filed for this ballot measure.</i></p>
+  </div>
 {% endif %}
+</section>
 
 {% endcapture %}
 {% include ballot-layout.html content=body ballot=ballot locality=locality %}

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -104,6 +104,13 @@ Beware: these objects are shaped differently (they have different properties).
     {% include contributions_by_type.html supporting_opposing=opposing color="red" %}
   </div>
 </section>
+{% else %}
+<section class="l-section">
+  <div class="l-section__content">
+    <p><i>No filings have been reported for this ballot measure.</i></p>
+  </div>
+</section>
+{% endif %}
 
 <!-- supporting contributions/expenditures column -->
 <section class="l-section">
@@ -126,13 +133,6 @@ Beware: these objects are shaped differently (they have different properties).
     {% include supporting_opposing_committees.html committees=opposing_organizations color="red" %}
   </div>
 </section>
-{% else %}
-<section class="l-section">
-  <div class="l-section__content">
-    <p><i>No filings have been reported for this ballot measure.</i></p>
-  </div>
-</section>
-{% endif %}
 
 {% endcapture %}
 {% include ballot-layout.html content=body ballot=ballot locality=locality %}

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -107,7 +107,7 @@ Beware: these objects are shaped differently (they have different properties).
 {% else %}
 <section class="l-section">
   <div class="l-section__content">
-    <p><i>No filings have been reported for this ballot measure.</i></p>
+    <p><i>No finance data available for this ballot measure.</i></p>
   </div>
 </section>
 {% endif %}

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -113,6 +113,7 @@ Beware: these objects are shaped differently (they have different properties).
 {% endif %}
 
 <!-- supporting contributions/expenditures column -->
+{% if supporting_organizations != empty or opposing_organizations != empty %}
 <section class="l-section">
   <div class="l-section__content">
     <h2>Spending breakdown by committee
@@ -133,6 +134,7 @@ Beware: these objects are shaped differently (they have different properties).
     {% include supporting_opposing_committees.html committees=opposing_organizations color="red" %}
   </div>
 </section>
+{% endif %}
 
 {% endcapture %}
 {% include ballot-layout.html content=body ballot=ballot locality=locality %}


### PR DESCRIPTION
This work resolves #277 

Display committees supporting or opposing measures even if `total_contributions` for `referendum_opposing` and `referendum_supporting` are 0.

Previously we were relying on `total_contributions` to display _any_ finance information for a measure. Now there are two separate checks: check `total_contributions` for the top sections "Contribution by type" and "Contribution by region", and check whether `supporting_organizations` or `opposing_organizations` are not empty for the bottom section, "Spending breakdown by committee".


### Previews

Large screens
![screen shot 2018-10-19 at 11 31 23 pm](https://user-images.githubusercontent.com/20404311/47252314-7948d800-d3f7-11e8-9483-092590602737.png)
