### PR TITLE
use smartify filter without escape

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -15,7 +15,7 @@
               <p {% if page.url == referendum.url %}class="current-page"{% endif %}>
                 <a href="{{ referendum.url | prepend: site.baseurl }}" tabindex="{{ tabIndxVar }}">
                   Measure {% if referendum.number %}{{ referendum.number }} {% endif %}
-                  <span class="ballot-nav__measure-title">{{ referendum.title | smartify | escape }}</span>
+                  <span class="ballot-nav__measure-title">{{ referendum.title | smartify }}</span>
                 </a>
               </p>
           {% endfor %}

--- a/_includes/candidate-photo.html
+++ b/_includes/candidate-photo.html
@@ -1,5 +1,5 @@
 {%- assign class = include.class -%}
-{%- assign alt = include.candidate.name | smartify | escape -%}
+{%- assign alt = include.candidate.name | smartify -%}
 {%- assign photo_url = include.candidate.photo_url | default: 'https://s3-us-west-1.amazonaws.com/odca-candidate-photos/no-image.png' -%}
 {%- if photo_url contains '://' -%}
 <img class="{{ class }}" src="{{ photo_url }}" alt="{{ alt }}" />

--- a/_includes/candidate-summary.html
+++ b/_includes/candidate-summary.html
@@ -8,7 +8,7 @@
     </a>
   </div>
   <div class="candidate-summary__right">
-    <div><a href="{{ candidate.url | prepend: site.baseurl }}">{{ candidate.name | smartify | escape }}</a></div>
+    <div><a href="{{ candidate.url | prepend: site.baseurl }}">{{ candidate.name | smartify }}</a></div>
     <div class="candidate-summary__occupation">{% if candidate.is_incumbent %}Incumbent, {% endif %}{{ candidate.occupation | default: 'No occupation reported' | escape }}</div>
     {% if finance.total_contributions > 0 %}
       <div class="candidate-summary__contributions">amount collected <span class="money">{{ finance.total_contributions | dollars }}</span></div>

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -1,3 +1,8 @@
+
+smartify: {{ '&' | smartify }}
+escape: {{ '&' | escape }}
+escape: {{ "'&'" | escape | smartify }}
+
 {% comment %}
 committee data expected this shape:
   committees = [
@@ -46,7 +51,7 @@ First we calculate the maximum for the money bar.
   {% assign name = committee.Filer_NamL | default: committee.name %}
 
   {% if filer_id != "pending" and filer_id != "Pending" and filer_id != "PENDING" %}
-  <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ name | smartify | escape }}</a></div>
+  <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ name | smartify }}</a></div>
   {% if money > 0 %}
     <div>{{ money | dollars }}</div>
     {% include money-bar.html value=money color=include.color max=max %}

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -1,8 +1,4 @@
 
-smartify: {{ '&' | smartify }}
-escape: {{ '&' | escape }}
-escape: {{ "'&'" | escape | smartify }}
-
 {% comment %}
 committee data expected this shape:
   committees = [

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -19,7 +19,7 @@ layout: default
 <div class="candidate">
   <header class="candidate__header grid">
     <div class="grid-col-12">
-      <h2>{{ candidate.name | smartify | escape }}</h2>
+      <h2>{{ candidate.name | smartify }}</h2>
     </div>
   </header>
   <div class="candidate__main">
@@ -40,7 +40,7 @@ layout: default
               {{ candidate.occupation }}
               {% endif %}
               {% if candidate.committee_name != null %}<span class="candidate__commitee-name"> {{
-                candidate.committee_name | smartify | escape }} </span>{% endif %}</div>
+                candidate.committee_name | smartify }} </span>{% endif %}</div>
             {% if candidate.is_accepted_expenditure_ceiling %}
             <div class="candidate__expenditure-ceiling">
               This candidate has agreed to voluntary spending limits.

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -40,9 +40,9 @@ Beware: these objects are shaped differently (they have different properties).
 <header>
   {% if referendum.number %}
     <h1>Measure {{ referendum.number }}</h1>
-    <h2>{{ referendum.title | smartify | escape }}</h2>
+    <h2>{{ referendum.title | smartify }}</h2>
   {% else %}
-    <h1>{{ referendum.title | smartify | escape }}</h1>
+    <h1>{{ referendum.title | smartify }}</h1>
     <div><p><i>No measure number has been assigned.</i></p></div>
   {% endif %}
 </header>


### PR DESCRIPTION
This work resolves #281

Using smartify and escape filters together is double-escaping _**'&'**_ character, causing it to render as _**'amp;'**_.

This PR replaces all `| smartify | escape` with just plain `| smartify` by itself.


### Previews
![screen shot 2018-10-23 at 10 10 21 pm](https://user-images.githubusercontent.com/20404311/47407530-7c520a00-d710-11e8-9d51-c3477a372693.png)
