### PR TITLE
A 404 is showing GH pages 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /404.html
 ---
 
 <style type="text/css" media="screen">


### PR DESCRIPTION
Set the permalink to 404.html which is what GH pages is looking for, rather than
our pretty links which renders to /404/index.html which won't work.

This work resolves #<issue-number>.

Please include a description of the work.


<!-- you may remove this section below if the PR does not include any visual changes -->
### Previews

Large screens

<!-- Please include a screenshot of the work on medium/large screens -->


Small screens

<!-- Please include a screenshot of the work on small screens -->
<!-- Hint: after upload you can change the markdown image to <img> tag with
     a `width=300` option so the image doesn't display at full width. -->
