### PR TITLE
Feat/new table fields

### DIFF
--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -3,8 +3,6 @@ $breakpoint--s1: 460px;
 $breakpoint--s2: $grid--medium;
 
 .contributors {
-  table-layout: fixed;
-  width: 100%;
   border-top: 3px $color-gold solid;
 }
 
@@ -15,16 +13,17 @@ $breakpoint--s2: $grid--medium;
     border-bottom: 1px $color-grey-4 solid;
   }
 
-  .sort-button {
-    border: 0;
-    text-align: left;
-    display: inline-block;
-    background-color: inherit;
-    width: 100%;
-    height: 100%;
-    padding: 0;
-    white-space: nowrap;
-  }
+}
+
+.sort-button {
+  border: 0;
+  text-align: left;
+  display: inline-block;
+  background-color: inherit;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  white-space: nowrap;
 }
 
 .arrow-container {
@@ -52,37 +51,26 @@ $breakpoint--s2: $grid--medium;
   }
 }
 
+.contributors__empty-cell {
+  padding-left: 2rem;
+}
+
 .contributors__name {
   padding: 0 $spacing-base;
 }
 
 .contributors__amount {
   padding: 0 $spacing-base;
-  // vertical-align: top;
-  // width: 35%;
 }
 
 .contributors__date {
   padding: 0 $spacing-base;
-  // vertical-align: top;
   white-space: nowrap;
-  // width: 25%;
 }
 
-@include media($breakpoint--s1) {
-  .contributors__amount {
-    // width: 25%;
-  }
-}
-
-@include media($breakpoint--s2) {
-  .contributors__amount {
-    // width: 20%;
-  }
-
-  .contributors__date {
-    // width: 20%;
-  }
+.contributors__occupation {
+  hyphens: auto;
+  -webkit-hyphenate-character: '';
 }
 
 .contributors__col--s1 {
@@ -104,5 +92,33 @@ contributions-table {
     .filter {
       width: 35%;
     }
+  }
+}
+
+.contributors__heading:not(.contributors__name),
+.contributors__cell:not(.contributors__name) {
+  display: none;
+}
+
+.contributors__name {
+  font-weight: bold;
+}
+
+.contributors__card {
+  font-weight: normal;
+}
+
+@media screen and (min-width: $grid--small) {
+  .contributors__heading:not(.contributors__name),
+  .contributors__cell:not(.contributors__name) {
+    display: table-cell;
+  }
+
+  .contributors__name {
+    font-weight: normal;
+  }
+
+  .contributors__card {
+    display: none;
   }
 }

--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -58,30 +58,30 @@ $breakpoint--s2: $grid--medium;
 
 .contributors__amount {
   padding: 0 $spacing-base;
-  vertical-align: top;
-  width: 35%;
+  // vertical-align: top;
+  // width: 35%;
 }
 
 .contributors__date {
   padding: 0 $spacing-base;
-  vertical-align: top;
+  // vertical-align: top;
   white-space: nowrap;
-  width: 25%;
+  // width: 25%;
 }
 
 @include media($breakpoint--s1) {
   .contributors__amount {
-    width: 25%;
+    // width: 25%;
   }
 }
 
 @include media($breakpoint--s2) {
   .contributors__amount {
-    width: 20%;
+    // width: 20%;
   }
 
   .contributors__date {
-    width: 20%;
+    // width: 20%;
   }
 }
 

--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -106,9 +106,18 @@ contributions-table {
 
 .contributors__card {
   font-weight: normal;
+
+  & span[class*='grid-col-'] {
+    margin-left: 0;
+  }
 }
 
-@media screen and (min-width: $grid--small) {
+.contributors__card-amount,
+.contributors__card-date {
+  text-align: right;
+}
+
+@include media($grid--small) {
   .contributors__heading:not(.contributors__name),
   .contributors__cell:not(.contributors__name) {
     display: table-cell;

--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -95,12 +95,26 @@ contributions-table {
   }
 }
 
+contributions-table .filter {
+  border: 2px solid $color-grey-5;
+}
+
 .contributors__sort-select {
   margin-bottom: 1rem;
   border-radius: 2px;
   border: 1px solid $color-navy;
-  padding: .8rem;
   width: 100%;
+  background-repeat: no-repeat;
+  background-position: 95% 54%;
+  background-image: url('data:image/svg+xml;utf8,\
+    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="8">\
+      <polygon points="0 2, 2 0, 6 4, 10 0, 12 2, 6 8" fill="black"></polygon>\
+    </svg>')
+}
+
+contributions-table .filter,
+.contributors__sort-select {
+  padding: .6rem;
 }
 
 .contributors__thead,
@@ -142,7 +156,10 @@ contributions-table {
     display: none;
   }
   
-  .contributors__heading,
+  .contributors__thead {
+    display: table-header-group;
+  }
+  
   .contributors__cell:not(.contributors__name) {
     display: table-cell;
   }

--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -106,10 +106,7 @@ contributions-table .filter {
   width: 100%;
   background-repeat: no-repeat;
   background-position: 95% 54%;
-  background-image: url('data:image/svg+xml;utf8,\
-    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="8">\
-      <polygon points="0 2, 2 0, 6 4, 10 0, 12 2, 6 8" fill="black"></polygon>\
-    </svg>')
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="8"><polygon points="0 2, 2 0, 6 4, 10 0, 12 2, 6 8" fill="black"></polygon></svg>');
 }
 
 contributions-table .filter,

--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -95,21 +95,33 @@ contributions-table {
   }
 }
 
-.contributors__heading:not(.contributors__name),
+.contributors__thead,
 .contributors__cell:not(.contributors__name) {
   display: none;
 }
 
 .contributors__name {
+  padding-top: 1.5rem;
   font-weight: bold;
 }
 
 .contributors__card {
   font-weight: normal;
+}
 
-  & span[class*='grid-col-'] {
-    margin-left: 0;
-  }
+.contributors__card-row {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+}
+
+.contributors__card-type,
+.contributors__card-zip,
+.contributors__card-date,
+.contributors__card-occupation,
+.contributors__card-employer {
+  @include font-size(1.6);
+  color: $color-grey-3;
 }
 
 .contributors__card-amount,
@@ -118,12 +130,13 @@ contributions-table {
 }
 
 @include media($grid--small) {
-  .contributors__heading:not(.contributors__name),
+  .contributors__heading,
   .contributors__cell:not(.contributors__name) {
     display: table-cell;
   }
 
   .contributors__name {
+    padding-top: 0;
     font-weight: normal;
   }
 

--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -95,6 +95,14 @@ contributions-table {
   }
 }
 
+.contributors__sort-select {
+  margin-bottom: 1rem;
+  border-radius: 2px;
+  border: 1px solid $color-navy;
+  padding: .8rem;
+  width: 100%;
+}
+
 .contributors__thead,
 .contributors__cell:not(.contributors__name) {
   display: none;
@@ -130,6 +138,10 @@ contributions-table {
 }
 
 @include media($grid--small) {
+  .contributors__sort-select {
+    display: none;
+  }
+  
   .contributors__heading,
   .contributors__cell:not(.contributors__name) {
     display: table-cell;

--- a/_sass/module/_contributors.scss
+++ b/_sass/module/_contributors.scss
@@ -120,7 +120,7 @@ contributions-table .filter,
 }
 
 .contributors__name {
-  padding-top: 1.5rem;
+  padding-top: 1.5rem; padding-bottom: 1rem;
   font-weight: bold;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,6 +312,149 @@
         "@babel/plugin-syntax-async-generators": "^7.0.0"
       }
     },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
+      "integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0",
+        "@babel/plugin-syntax-class-properties": "^7.0.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
+          "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+          "requires": {
+            "@babel/types": "^7.1.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.10",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.1.3",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
+              "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+              }
+            }
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
+          "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.0.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
+          "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w=="
+        },
+        "@babel/template": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+          "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.1.2",
+            "@babel/types": "^7.1.2"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.1.3",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
+              "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+              }
+            }
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
+          "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.1.3",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/parser": "^7.1.3",
+            "@babel/types": "^7.1.3",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.10"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.1.3",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
+              "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.8.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+          "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
@@ -386,6 +529,14 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
       "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
+      "integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -2510,7 +2661,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -9886,7 +10037,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -197,16 +197,14 @@ class ContributionsTable extends React.Component {
       <div>
         <input className="filter" value={this.state.filterField} onChange={updateFilter} type="text" placeholder="Type to filter contributions" />
         <select className="contributors__sort-select" onChange={ e => this.updateSortOrder(e) }>
-          <option value={'{ "column": "name", "order": 1}'}>Name A-Z</option>
-          <option value={'{ "column": "name", "order": -1}'}>Name Z-A</option>
-          <option value={'{ "column": "type", "order": 1}'}>Contributor type A-Z</option>
-          <option value={'{ "column": "type", "order": -1}'}>Contriubtor type Z-A</option>
-          <option value={'{ "column": "amount", "order": 1}'}>Amount hi-lo</option>
-          <option value={'{ "column": "amount", "order": -1}'}>Amount lo-hi</option>
-          <option value={'{ "column": "zip", "order": 1}'}>Zip hi-lo</option>
-          <option value={'{ "column": "zip", "order": -1}'}>Zip lo-hi</option>
-          <option value={'{ "column": "date", "order": 1}'}>Date hi-lo</option>
-          <option value={'{ "column": "date", "order": -1}'}>Date lo-hi</option>
+          <option value={'{ "column": "name", "order": 1}'}>Name (A-Z)</option>
+          <option value={'{ "column": "name", "order": -1}'}>Name (Z-A)</option>
+          <option value={'{ "column": "type", "order": 1}'}>Contributor type (A-Z)</option>
+          <option value={'{ "column": "type", "order": -1}'}>Contriubtor type (Z-A)</option>
+          <option value={'{ "column": "amount", "order": 1}'}>Amount (high to low)</option>
+          <option value={'{ "column": "amount", "order": -1}'}>Amount (high to low)</option>
+          <option value={'{ "column": "date", "order": -1}'}>Date (first to last)</option>
+          <option value={'{ "column": "date", "order": 1}'}>Date (last to first)</option>
         </select>
         <table className="contributors">
           <thead className="contributors__thead">

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -51,6 +51,14 @@ class ContributionsTable extends React.Component {
     this.state = ContributionsTable.initialState(props.contributions);
   }
 
+  codepointCompare = (a, b) => {
+    return (a > b
+      ? 1
+      : (a < b
+      ? -1
+      : 0))
+  }
+
   /**
    * applyFilter
    *
@@ -88,6 +96,8 @@ class ContributionsTable extends React.Component {
 
   applySortOrder(contributions) {
     const { sort } = this.state;
+    const codepointCompare = this.codepointCompare;
+
     function difference(a, b) {
       // We're doing some funkiness with ascending/decsending based on the
       // column to give a _maybe_ more intuitive behavior. The default sort is
@@ -100,11 +110,11 @@ class ContributionsTable extends React.Component {
         case 'name':
           return a.name.localeCompare(b.name);
         case 'type':
-          return a.type.localeCompare(b.type);
+          return codepointCompare(a.type, b.type);
         case 'occupation':
-          return a.occupation.localeCompare(b.occupation);
+          return codepointCompare(a.occupation, b.occupation);
         case 'employer':
-          return a.employer.localeCompare(b.employer);
+          return codepointCompare(a.employer, b.employer);
         case 'date':
           return b.date.valueOf() - a.date.valueOf();
         case 'zip':

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -17,8 +17,9 @@ class ContributionsTable extends React.Component {
       contributions: contributions.map((contribution, i) => ({
         id: i,
         name: name(contribution),
-        occupation: contribution.Tran_Occ,
-        employer: contribution.Tran_Emp,
+        type: contribution.Contributor_type || '—', // ATTENTION: this is a PLACEHOLDER. I don't know what this field is called until I get it from the backend
+        occupation: contribution.Tran_Occ || '—',
+        employer: contribution.Tran_Emp || '—',
         zip: contribution.Tran_Zip4,
         amount: contribution.Tran_Amt1,
         date: new Date(contribution.Tran_Date),
@@ -98,8 +99,16 @@ class ContributionsTable extends React.Component {
           return b.amount - a.amount;
         case 'name':
           return a.name.localeCompare(b.name);
+        case 'type':
+          return a.type.localeCompare(b.type);
+        case 'occupation':
+          return a.occupation.localeCompare(b.occupation);
+        case 'employer':
+          return a.employer.localeCompare(b.employer);
         case 'date':
           return b.date.valueOf() - a.date.valueOf();
+        case 'zip':
+          return +(b.zip.replace('-', '').padEnd(9, '0')) - +(a.zip.replace('-', '').padEnd(9, '0'))
         default:
           return 0;
       }
@@ -205,10 +214,10 @@ class ContributionsTable extends React.Component {
               this.applySortOrder(this.applyFilter(contributions)).map(contribution => (
                 <tr key={contribution.id}>
                   <td className="contributors__name">{contribution.name}</td>
-                  <td className="contributors__type">{dollars(contribution.type)}</td>
-                  <td className="contributors__occupation">{dollars(contribution.occupation)}</td>
-                  <td className="contributors__employer">{dollars(contribution.employer)}</td>
-                  <td className="contributors__zip">{dollars(contribution.zip)}</td>
+                  <td className="contributors__type">{contribution.type || '—'}</td>
+                  <td className="contributors__occupation">{contribution.occupation || '—'}</td>
+                  <td className="contributors__employer">{contribution.employer || '—'}</td>
+                  <td className="contributors__zip">{contribution.zip || '—'}</td>
                   <td className="contributors__amount">{dollars(contribution.amount)}</td>
                   <td className="contributors__date contributors__col--s1">{day(contribution.date)}</td>
                 </tr>

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -184,6 +184,18 @@ class ContributionsTable extends React.Component {
     return (
       <div>
         <input className="filter" value={this.state.filterField} onChange={updateFilter} type="text" placeholder="Type to filter contributions" />
+        <select className="contributors__sort-select" value={"Sort by: " + this.state.sort.column } onChange="">
+          <option>Name A-Z</option>
+          <option>Name Z-A</option>
+          <option>Contributor type A-Z</option>
+          <option>Contriubtor type Z-A</option>
+          <option>Amount hi-lo</option>
+          <option>Amount lo-hi</option>
+          <option>Zip hi-lo</option>
+          <option>Zip lo-hi</option>
+          <option>Date hi-lo</option>
+          <option>Date lo-hi</option>
+        </select>
         <table className="contributors">
           <thead className="contributors__thead">
             <tr>

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -97,7 +97,19 @@ class ContributionsTable extends React.Component {
       });
   }
 
-  applySortOrder = (contributions) => {
+  updateSortOrder = e => {
+    const value = JSON.parse(e.target.value);
+    this.setState(() => {
+      return {
+        sort: {
+          order: value.order,
+          column: value.column
+        }
+      }
+    })
+  }
+
+  applySortOrder = contributions => {
     const { sort } = this.state;
 
     const difference = (a, b) => {
@@ -184,17 +196,17 @@ class ContributionsTable extends React.Component {
     return (
       <div>
         <input className="filter" value={this.state.filterField} onChange={updateFilter} type="text" placeholder="Type to filter contributions" />
-        <select className="contributors__sort-select" value={"Sort by: " + this.state.sort.column } onChange="">
-          <option>Name A-Z</option>
-          <option>Name Z-A</option>
-          <option>Contributor type A-Z</option>
-          <option>Contriubtor type Z-A</option>
-          <option>Amount hi-lo</option>
-          <option>Amount lo-hi</option>
-          <option>Zip hi-lo</option>
-          <option>Zip lo-hi</option>
-          <option>Date hi-lo</option>
-          <option>Date lo-hi</option>
+        <select className="contributors__sort-select" onChange={ e => this.updateSortOrder(e) }>
+          <option value={'{ "column": "name", "order": 1}'}>Name A-Z</option>
+          <option value={'{ "column": "name", "order": -1}'}>Name Z-A</option>
+          <option value={'{ "column": "type", "order": 1}'}>Contributor type A-Z</option>
+          <option value={'{ "column": "type", "order": -1}'}>Contriubtor type Z-A</option>
+          <option value={'{ "column": "amount", "order": 1}'}>Amount hi-lo</option>
+          <option value={'{ "column": "amount", "order": -1}'}>Amount lo-hi</option>
+          <option value={'{ "column": "zip", "order": 1}'}>Zip hi-lo</option>
+          <option value={'{ "column": "zip", "order": -1}'}>Zip lo-hi</option>
+          <option value={'{ "column": "date", "order": 1}'}>Date hi-lo</option>
+          <option value={'{ "column": "date", "order": -1}'}>Date lo-hi</option>
         </select>
         <table className="contributors">
           <thead className="contributors__thead">

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -17,9 +17,9 @@ class ContributionsTable extends React.Component {
       contributions: contributions.map((contribution, i) => ({
         id: i,
         name: name(contribution),
-        type: contribution.Contributor_type || '—', // ATTENTION: this is a PLACEHOLDER. I don't know what this field is called until I get it from the backend
-        occupation: contribution.Tran_Occ || '—',
-        employer: contribution.Tran_Emp || '—',
+        type: contribution.Contributor_type || '', // ATTENTION: this is a PLACEHOLDER. I don't know what this field is called until I get it from the backend
+        occupation: contribution.Tran_Occ || '',
+        employer: contribution.Tran_Emp || '',
         zip: contribution.Tran_Zip4,
         amount: contribution.Tran_Amt1,
         date: new Date(contribution.Tran_Date),
@@ -51,7 +51,10 @@ class ContributionsTable extends React.Component {
     this.state = ContributionsTable.initialState(props.contributions);
   }
 
-  codepointCompare = (a, b) => {
+  codepointCompare = (x, y) => {
+    // sort falsey values to the bottom, rather than to the top
+    const [a, b] = [x || '\uffff', y || '\uffff']
+
     return (a > b
       ? 1
       : (a < b
@@ -94,11 +97,10 @@ class ContributionsTable extends React.Component {
       });
   }
 
-  applySortOrder(contributions) {
+  applySortOrder = (contributions) => {
     const { sort } = this.state;
-    const codepointCompare = this.codepointCompare;
 
-    function difference(a, b) {
+    const difference = (a, b) => {
       // We're doing some funkiness with ascending/decsending based on the
       // column to give a _maybe_ more intuitive behavior. The default sort is
       // ascending, but if you sort by amount, you probably want that to start in
@@ -110,11 +112,11 @@ class ContributionsTable extends React.Component {
         case 'name':
           return a.name.localeCompare(b.name);
         case 'type':
-          return codepointCompare(a.type, b.type);
+          return this.codepointCompare(a.type, b.type);
         case 'occupation':
-          return codepointCompare(a.occupation, b.occupation);
+          return this.codepointCompare(a.occupation, b.occupation);
         case 'employer':
-          return codepointCompare(a.employer, b.employer);
+          return this.codepointCompare(a.employer, b.employer);
         case 'date':
           return b.date.valueOf() - a.date.valueOf();
         case 'zip':
@@ -131,6 +133,16 @@ class ContributionsTable extends React.Component {
 
   render() {
     const { contributions } = this.state;
+
+    const maybeReturnEmptyCell = (contribution, key) => {
+      const baseClass = `contributors__${key}`
+      const [classList, display] = contribution[key]
+        ? [ baseClass, contribution[key] ]
+        : [ baseClass + " contributors__empty-cell", "—"]
+
+      return <td className={ classList }>{ display }</td>
+    }
+
     const sortToggle = column => () => {
       const currentSort = this.state.sort;
       if (currentSort.column === column) {
@@ -225,7 +237,7 @@ class ContributionsTable extends React.Component {
                 <tr key={contribution.id}>
                   <td className="contributors__name">{contribution.name}</td>
                   <td className="contributors__type">{contribution.type || '—'}</td>
-                  <td className="contributors__occupation">{contribution.occupation || '—'}</td>
+                  { maybeReturnEmptyCell(contribution, 'occupation') }
                   <td className="contributors__employer">{contribution.employer || '—'}</td>
                   <td className="contributors__zip">{contribution.zip || '—'}</td>
                   <td className="contributors__amount">{dollars(contribution.amount)}</td>

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -238,15 +238,17 @@ class ContributionsTable extends React.Component {
                   <td className="contributors__cell contributors__name">
                     {contribution.name}
                     <div className="contributors__card">
-                      <div className="grid">
-                        <span className="grid-col-6--xs contributors__card-type">{ contribution.type }</span>
-                        <span className="grid-col-6--xs contributors__card-amount">{ '$' + contribution.amount }</span>
+                      <div className="contributors__card-row">
+                        <span className="contributors__card-type">{ contribution.type }</span>
+                        <span className="contributors__card-amount">{ '$' + contribution.amount }</span>
                       </div>
-                      <div>
-                        <span className="grid-col-6--xs contributors__card-zip">{ contribution.zip }</span>
-                        <span className="grid-col-6--xs contributors__card-date">{ day(contribution.date) }</span>
+                      <div className="contributors__card-row">
+                        <span className="contributors__card-zip">Zip code: { contribution.zip }</span>
+                        <span className="contributors__card-date">{ day(contribution.date) }</span>
                       </div>
-                      <div>{ contribution.occupation || '' }{ contribution.employer ? ', ' + contribution.employer : '' }</div>
+                      <div
+                        className="contributors__card-occupation contributors__card-employer"
+                      >{ contribution.occupation || '' }{ contribution.employer ? ', ' + contribution.employer : '' }</div>
                     </div>
                   </td>
                   { maybeReturnEmptyCell(contribution, 'type') }

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -17,6 +17,9 @@ class ContributionsTable extends React.Component {
       contributions: contributions.map((contribution, i) => ({
         id: i,
         name: name(contribution),
+        occupation: contribution.Tran_Occ,
+        employer: contribution.Tran_Emp,
+        zip: contribution.Tran_Zip4,
         amount: contribution.Tran_Amt1,
         date: new Date(contribution.Tran_Date),
       })),
@@ -159,6 +162,30 @@ class ContributionsTable extends React.Component {
                   <span className="arrow-container" />
                 </button>
               </th>
+              <th className={`contributors__type${isActive('type')}`}>
+                <button type="button" className="sort-button type" onClick={sortToggle('type')}>
+                  Contributor type
+                  <span className="arrow-container" />
+                </button>
+              </th>
+              <th className={`contributors__occupation${isActive('occupation')}`}>
+                <button type="button" className="sort-button occupation" onClick={sortToggle('occupation')}>
+                  Occupation
+                  <span className="arrow-container" />
+                </button>
+              </th>
+              <th className={`contributors__employer${isActive('employer')}`}>
+                <button type="button" className="sort-button employer" onClick={sortToggle('employer')}>
+                  Employer
+                  <span className="arrow-container" />
+                </button>
+              </th>
+              <th className={`contributors__zip${isActive('zip')}`}>
+                <button type="button" className="sort-button zip" onClick={sortToggle('zip')}>
+                  ZIP code
+                  <span className="arrow-container" />
+                </button>
+              </th>
               <th className={`contributors__amount${isActive('amount')}`}>
                 <button type="button" className="sort-button amount" onClick={sortToggle('amount')}>
                   Amount
@@ -178,6 +205,10 @@ class ContributionsTable extends React.Component {
               this.applySortOrder(this.applyFilter(contributions)).map(contribution => (
                 <tr key={contribution.id}>
                   <td className="contributors__name">{contribution.name}</td>
+                  <td className="contributors__type">{dollars(contribution.type)}</td>
+                  <td className="contributors__occupation">{dollars(contribution.occupation)}</td>
+                  <td className="contributors__employer">{dollars(contribution.employer)}</td>
+                  <td className="contributors__zip">{dollars(contribution.zip)}</td>
                   <td className="contributors__amount">{dollars(contribution.amount)}</td>
                   <td className="contributors__date contributors__col--s1">{day(contribution.date)}</td>
                 </tr>

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -196,13 +196,13 @@ class ContributionsTable extends React.Component {
     return (
       <div>
         <input className="filter" value={this.state.filterField} onChange={updateFilter} type="text" placeholder="Type to filter contributions" />
-        <select className="contributors__sort-select" onChange={ e => this.updateSortOrder(e) }>
+        <select className="contributors__sort-select" defaultValue={'{ "column": "amount", "order": 1}'} onChange={ e => this.updateSortOrder(e) }>
           <option value={'{ "column": "name", "order": 1}'}>Name (A-Z)</option>
           <option value={'{ "column": "name", "order": -1}'}>Name (Z-A)</option>
           <option value={'{ "column": "type", "order": 1}'}>Contributor type (A-Z)</option>
           <option value={'{ "column": "type", "order": -1}'}>Contriubtor type (Z-A)</option>
           <option value={'{ "column": "amount", "order": 1}'}>Amount (high to low)</option>
-          <option value={'{ "column": "amount", "order": -1}'}>Amount (high to low)</option>
+          <option value={'{ "column": "amount", "order": -1}'}>Amount (low to high)</option>
           <option value={'{ "column": "date", "order": -1}'}>Date (first to last)</option>
           <option value={'{ "column": "date", "order": 1}'}>Date (last to first)</option>
         </select>

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -238,9 +238,15 @@ class ContributionsTable extends React.Component {
                   <td className="contributors__cell contributors__name">
                     {contribution.name}
                     <div className="contributors__card">
-                      <div>{ contribution.type } | { contribution.amount }</div>
-                      <div>{ contribution.zip } | { day(contribution.date) }</div>
-                      <div>{ contribution.occupation }, { contribution.employer }</div>
+                      <div className="grid">
+                        <span className="grid-col-6--xs contributors__card-type">{ contribution.type }</span>
+                        <span className="grid-col-6--xs contributors__card-amount">{ '$' + contribution.amount }</span>
+                      </div>
+                      <div>
+                        <span className="grid-col-6--xs contributors__card-zip">{ contribution.zip }</span>
+                        <span className="grid-col-6--xs contributors__card-date">{ day(contribution.date) }</span>
+                      </div>
+                      <div>{ contribution.occupation || '' }{ contribution.employer ? ', ' + contribution.employer : '' }</div>
                     </div>
                   </td>
                   { maybeReturnEmptyCell(contribution, 'type') }

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -135,7 +135,7 @@ class ContributionsTable extends React.Component {
     const { contributions } = this.state;
 
     const maybeReturnEmptyCell = (contribution, key) => {
-      const baseClass = `contributors__${key}`
+      const baseClass = `contributors__cell contributors__${key}`
       const [classList, display] = contribution[key]
         ? [ baseClass, contribution[key] ]
         : [ baseClass + " contributors__empty-cell", "—"]
@@ -187,43 +187,43 @@ class ContributionsTable extends React.Component {
         <table className="contributors">
           <thead className="contributors__thead">
             <tr>
-              <th className={`contributors__name${isActive('name')}`}>
+              <th className={`contributors__heading contributors__name${isActive('name')}`}>
                 <button type="button" className="sort-button" onClick={sortToggle('name')}>
                   Name
                   <span className="arrow-container" />
                 </button>
               </th>
-              <th className={`contributors__type${isActive('type')}`}>
+              <th className={`contributors__heading contributors__type${isActive('type')}`}>
                 <button type="button" className="sort-button type" onClick={sortToggle('type')}>
                   Contributor type
                   <span className="arrow-container" />
                 </button>
               </th>
-              <th className={`contributors__occupation${isActive('occupation')}`}>
+              <th className={`contributors__heading contributors__occupation${isActive('occupation')}`}>
                 <button type="button" className="sort-button occupation" onClick={sortToggle('occupation')}>
                   Occupation
                   <span className="arrow-container" />
                 </button>
               </th>
-              <th className={`contributors__employer${isActive('employer')}`}>
+              <th className={`contributors__heading contributors__employer${isActive('employer')}`}>
                 <button type="button" className="sort-button employer" onClick={sortToggle('employer')}>
                   Employer
                   <span className="arrow-container" />
                 </button>
               </th>
-              <th className={`contributors__zip${isActive('zip')}`}>
+              <th className={`contributors__heading contributors__zip${isActive('zip')}`}>
                 <button type="button" className="sort-button zip" onClick={sortToggle('zip')}>
                   ZIP code
                   <span className="arrow-container" />
                 </button>
               </th>
-              <th className={`contributors__amount${isActive('amount')}`}>
+              <th className={`contributors__heading contributors__amount${isActive('amount')}`}>
                 <button type="button" className="sort-button amount" onClick={sortToggle('amount')}>
                   Amount
                   <span className="arrow-container" />
                 </button>
               </th>
-              <th className={`contributors__date contributors__col--s1${isActive('date')}`}>
+              <th className={`contributors__heading contributors__date contributors__col--s1${isActive('date')}`}>
                 <button type="button" className="sort-button" onClick={sortToggle('date')}>
                   Date
                   <span className="arrow-container" />
@@ -235,13 +235,20 @@ class ContributionsTable extends React.Component {
             {
               this.applySortOrder(this.applyFilter(contributions)).map(contribution => (
                 <tr key={contribution.id}>
-                  <td className="contributors__name">{contribution.name}</td>
+                  <td className="contributors__cell contributors__name">
+                    {contribution.name}
+                    <div className="contributors__card">
+                      <div>{ contribution.type } | { contribution.amount }</div>
+                      <div>{ contribution.zip } | { day(contribution.date) }</div>
+                      <div>{ contribution.occupation }, { contribution.employer }</div>
+                    </div>
+                  </td>
                   { maybeReturnEmptyCell(contribution, 'type') }
                   { maybeReturnEmptyCell(contribution, 'occupation') }
                   { maybeReturnEmptyCell(contribution, 'employer') }
                   { maybeReturnEmptyCell(contribution, 'zip') }
-                  <td className="contributors__amount">{dollars(contribution.amount)}</td>
-                  <td className="contributors__date contributors__col--s1">{day(contribution.date)}</td>
+                  <td className="contributors__cell contributors__amount">{dollars(contribution.amount)}</td>
+                  <td className="contributors__cell contributors__date contributors__col--s1">{day(contribution.date)}</td>
                 </tr>
               ))
             }

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -17,7 +17,7 @@ class ContributionsTable extends React.Component {
       contributions: contributions.map((contribution, i) => ({
         id: i,
         name: name(contribution),
-        type: contribution.Contributor_type || '', // ATTENTION: this is a PLACEHOLDER. I don't know what this field is called until I get it from the backend
+        type: contribution.Entity_Cd || '',
         occupation: contribution.Tran_Occ || '',
         employer: contribution.Tran_Emp || '',
         zip: contribution.Tran_Zip4,
@@ -236,10 +236,10 @@ class ContributionsTable extends React.Component {
               this.applySortOrder(this.applyFilter(contributions)).map(contribution => (
                 <tr key={contribution.id}>
                   <td className="contributors__name">{contribution.name}</td>
-                  <td className="contributors__type">{contribution.type || '—'}</td>
+                  { maybeReturnEmptyCell(contribution, 'type') }
                   { maybeReturnEmptyCell(contribution, 'occupation') }
-                  <td className="contributors__employer">{contribution.employer || '—'}</td>
-                  <td className="contributors__zip">{contribution.zip || '—'}</td>
+                  { maybeReturnEmptyCell(contribution, 'employer') }
+                  { maybeReturnEmptyCell(contribution, 'zip') }
                   <td className="contributors__amount">{dollars(contribution.amount)}</td>
                   <td className="contributors__date contributors__col--s1">{day(contribution.date)}</td>
                 </tr>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
                 loader: 'babel-loader',
                 options: {
                     presets: ['@babel/preset-env', '@babel/react'],
+                    plugins: ['module:@babel/plugin-proposal-class-properties']
                 },
             }
         ]


### PR DESCRIPTION
This work resolves #246 

Adds columns _contributor type_, _occupation_, _employer_, and _zip code_ to contributors table.

Creates a card-style layout of contributors columns on mobile. Adds a select menu for sort order on mobile.


### Previews

Large screens
![screen shot 2018-12-19 at 10 28 11 am](https://user-images.githubusercontent.com/20404311/50240374-7b88cd80-0379-11e9-9b93-fb9d97337455.png)


Small screens
<img src="https://user-images.githubusercontent.com/20404311/50240760-8001b600-037a-11e9-8afb-bab2f1c18e50.png" width="300" alt="contributors table mobile, screen shot 2018-12-19 at 10 40 12 am" />

<img src="https://user-images.githubusercontent.com/20404311/50240195-00271c00-0379-11e9-8228-bcf88be244e5.png" width="300" alt="contributors table sort select menu on mobile, screen shot 2018-12-19 at 10 29 10 am" />


<!-- Hint: after upload you can change the markdown image to <img> tag with
     a `width=300` option so the image doesn't display at full width. -->
