### PR TITLE
Allow contribution search with more fields

### DIFF
--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -80,7 +80,7 @@ class ContributionsTable extends React.Component {
           tokenize(contribution.name)
           .concat(tokenize(contribution.employer))
           .concat(tokenize(contribution.occupation))
-          .concat(contribution.zip)
+          .concat(String(contribution.zip))
           .concat(String(contribution.amount));
         const queries = tokenize(filter);
 

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -76,7 +76,12 @@ class ContributionsTable extends React.Component {
 
     return contributions
       .filter((contribution) => {
-        const tokens = tokenize(contribution.name);
+        const tokens =
+          tokenize(contribution.name)
+          .concat(tokenize(contribution.employer))
+          .concat(tokenize(contribution.occupation))
+          .concat(contribution.zip)
+          .concat(String(contribution.amount));
         const queries = tokenize(filter);
 
         // Every query needs to match at least one token. It's considered a

--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -76,8 +76,7 @@ class ContributionsTable extends React.Component {
 
     return contributions
       .filter((contribution) => {
-        const tokens =
-          tokenize(contribution.name)
+        const tokens = tokenize(contribution.name)
           .concat(tokenize(contribution.employer))
           .concat(tokenize(contribution.occupation))
           .concat(String(contribution.zip))


### PR DESCRIPTION
This adds support for searching the contribution list by employer, occupation, zip code, and amount. This is based on [Casey's feedback doc][1] of improvements for professional campaign finance researchers.

This work resolves #307.

[1]: https://docs.google.com/document/d/1vZj-u4fmc8EPMmAhdbJbdp-VgmS8vJBQukbbildJTI0/edit#

### Previews
This preview shows four use-cases:
1. Searching for contributions from retired people in my zip code
2. Searching for people who contributed the maximum in my zip code
3. Searching for contributions from "union" employees as well as the unions themself.
4. Searching for contributions by self-reported "developer"s

![Kapture 2019-04-30 at 22 47 44](https://user-images.githubusercontent.com/129120/57007008-3cc21a00-6b9a-11e9-98e2-bb2e1fa4746c.gif)
