### PR TITLE
Add link to Open Disclosure Alerts on homepage

### DIFF
--- a/_sass/module/_landing-description.scss
+++ b/_sass/module/_landing-description.scss
@@ -10,6 +10,10 @@
 
 .landing__description {
   padding: 50px;
+
+  & + & {
+    border-top: 1px solid $color-grey-4-5;
+  }
 }
 
 .landing__description__paragraph {

--- a/index.html
+++ b/index.html
@@ -76,3 +76,11 @@ header: Track the money in Oakland elections
     political participation by Oakland residents.
   </p>
 </div>
+<div class="landing__description">
+  <h3 class="landing__description__header">Sign up for daily campaign finance alerts.</h3>
+  <p class="landing__description__paragraph">Every day, Oakland's lobbyists, candidates, and decisionmakers are required to disclose their finances. Open Disclosure Alerts help you stay on top of the influence of money on your local politics.</p>
+
+  <p class="landing__description__paragraph">
+    <strong><a href="http://alert.opendisclosure.io" class="btn">Sign up for daily alerts</a></strong>
+  </p>
+</div>

--- a/index.html
+++ b/index.html
@@ -81,6 +81,6 @@ header: Track the money in Oakland elections
   <p class="landing__description__paragraph">Every day, Oakland's lobbyists, candidates, and decisionmakers are required to disclose their finances. Open Disclosure Alerts help you stay on top of the influence of money on your local politics.</p>
 
   <p class="landing__description__paragraph">
-    <strong><a href="http://alert.opendisclosure.io" class="btn">Sign up for daily alerts</a></strong>
+    <strong><a href="https://alert.opendisclosure.io" class="btn">Sign up for daily alerts</a></strong>
   </p>
 </div>


### PR DESCRIPTION
In talking with Suzanne, we are hoping to pilot the alert emails more
broadly. Perhaps it is a bit premature to put a link to sign up for the
alerts on the OpenDisclosure.io homepage (I'll check with Suzanne), but
I'd like to have this ready to go in case we are ready.

Pretty straightforward layout, this adds an adjacent sibiling selector
to separate homepage description blocks with a border if there are
multiple.

# preview
![image](https://user-images.githubusercontent.com/129120/57058432-bc1c2000-6c64-11e9-9aa9-9b50dc096dac.png)
