### PR TITLE
Remove waffle badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![CircleCI](https://circleci.com/gh/caciviclab/odca-jekyll.svg?style=svg)](https://circleci.com/gh/caciviclab/odca-jekyll)
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/caciviclab/disclosure-backend.png?columns=ready)](https://waffle.io/caciviclab/disclosure-backend?utm_source=badge)
 
 # www.opendisclosure.io
 


### PR DESCRIPTION
Having the disabled badge looked odd. If Zenhub gets a badge, it'd be cool to add that in this place but I don't think it exists yet.