### PR TITLE
Add 2020 elections to admin page

### DIFF
--- a/admin.md
+++ b/admin.md
@@ -2,6 +2,8 @@
 title: Admin
 ---
 
+{% include admin/ballot_index.html locality="oakland" election="2020-03-03" %}
+{% include admin/ballot_index.html locality="oakland" election="2020-11-03" %}
 {% include admin/ballot_index.html locality="oakland" election="2018-11-06" %}
 {% include admin/ballot_index.html locality="oakland" election="2018-06-05" %}
 {% include admin/ballot_index.html locality="oakland" election="2016-11-08" %}


### PR DESCRIPTION
This work resolves #328.

<img width="992" alt="Screen Shot 2020-02-12 at 7 58 40 AM" src="https://user-images.githubusercontent.com/28023047/74352526-836db300-4d6d-11ea-87f9-ac80adefaa96.png">
