### PR TITLE
Update contribution limit text on candidate page for 2020

### DIFF
--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -49,6 +49,7 @@ layout: default
             {% assign election_year = ballot.election | slice: 0, 4 | plus: 0 %}
             {% assign contribution_limit = locality.contribution_limit | where: 'election_year', election_year | first %}
             <div class="candidate__expenditure-ceiling">
+              This candidate has agreed to voluntary spending limits.
               {{ contribution_limit.text }}
               {% capture tooltip_message -%}
               For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/resources/oakland-campaign-contribution-limits" target="_blank">

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -48,8 +48,11 @@ layout: default
             {% if candidate.is_accepted_expenditure_ceiling %}
             <div class="candidate__expenditure-ceiling">
               This candidate has agreed to voluntary spending limits.
-              The maximum contribution this candidate can accept is $800 from any individual, business entity,
-              committee or other organization and $1,600 from a qualified broad-based committee.
+              The maximum contribution this candidate can accept is $900 from any individual, business entity, 
+              committee or other organization and $1,700 from a qualified broad-based committee.
+              If the candidate does not accept spending limits then:
+              The maximum contribution this candidate can accept is $200 from any individual, business entity, 
+              committee or other organization and $400 from a qualified broad-based committee.
               {% capture tooltip_message -%}
               For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/resources/oakland-campaign-contribution-limits" target="_blank">
               Public Ethics Commission Candidate Resources page</a>.

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -46,13 +46,10 @@ layout: default
               {% if candidate.committee_name != null %}<span class="candidate__commitee-name"> {{
                 candidate.committee_name | smartify }} </span>{% endif %}</div>
             {% if candidate.is_accepted_expenditure_ceiling %}
+            {% assign election_year = ballot.election | slice: 0, 4 | plus: 0 %}
+            {% assign contribution_limit = locality.contribution_limit | where: 'election_year', election_year | first %}
             <div class="candidate__expenditure-ceiling">
-              This candidate has agreed to voluntary spending limits.
-              The maximum contribution this candidate can accept is $900 from any individual, business entity, 
-              committee or other organization and $1,700 from a qualified broad-based committee.
-              If the candidate does not accept spending limits then:
-              The maximum contribution this candidate can accept is $200 from any individual, business entity, 
-              committee or other organization and $400 from a qualified broad-based committee.
+              {{ contribution_limit.text }}
               {% capture tooltip_message -%}
               For more on Oakland contribution limits and campaign rules, see the <a href="https://www.oaklandca.gov/resources/oakland-campaign-contribution-limits" target="_blank">
               Public Ethics Commission Candidate Resources page</a>.

--- a/_localities/oakland.md
+++ b/_localities/oakland.md
@@ -5,4 +5,15 @@ name: Oakland
 full_name: City of Oakland
 current_election: 2018-06-05
 referendum_measure_display: measure
+contribution_limit:
+    - election_year: 2020
+      text: >
+        The maximum contribution this candidate can accept is $900 from any individual, business entity, committee or other organization and $1,700 from a qualified broad-based committee.
+        If the candidate does not accept spending limits then:
+        The maximum contribution this candidate can accept is $200 from any individual, business entity, committee or other organization and $400 from a qualified broad-based committee.
+    - election_year: 2018
+      text: >
+        This candidate has agreed to voluntary spending limits.
+        The maximum contribution this candidate can accept is $800 from any individual, business entity,
+        committee or other organization and $1,600 from a qualified broad-based committee.
 ---

--- a/_localities/oakland.md
+++ b/_localities/oakland.md
@@ -13,7 +13,6 @@ contribution_limit:
         The maximum contribution this candidate can accept is $200 from any individual, business entity, committee or other organization and $400 from a qualified broad-based committee.
     - election_year: 2018
       text: >
-        This candidate has agreed to voluntary spending limits.
         The maximum contribution this candidate can accept is $800 from any individual, business entity,
         committee or other organization and $1,600 from a qualified broad-based committee.
 ---


### PR DESCRIPTION
This work resolves #335

This adds a field `contribution_limit` to Oakland's locality data, _locality/oakland.md, that contains an array of contribution limit text for different years:
```yaml
contribution_limit:
  - election_year: 2020
    text: >
      The maximum contribution this candidate can accept is $900...etc...
  - election_year: 2018
    text: >
      The maximum contribution this candidate can accept is $800...etc...
```

This way, we can change contribution limits text from year to year and still have past years' contribution limit statement be true.

### Previews

#### 2018 candidate 

![Screen Shot 2020-02-12 at 10 33 07 AM](https://user-images.githubusercontent.com/20404311/74365814-a905b700-4d83-11ea-87c1-9b2ea2b86b43.png)


#### 2020 candidate

![Screen Shot 2020-02-12 at 10 32 58 AM](https://user-images.githubusercontent.com/20404311/74365826-ac993e00-4d83-11ea-9e26-842a4df14409.png)
