### PR TITLE
fix match condition for highlighting nav item

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -41,7 +41,7 @@
       {% for office_election_path in ballot_item.items %}
       {% assign tabIndxVar = tabIndxVar | plus:1 %}
       {% assign office_election = site.office_elections | where: "path", office_election_path | first %}
-      <li class="ballot-nav__list-item{% if page.url == referendum.url %} current-page{% endif %}">
+      <li class="ballot-nav__list-item{% if page.url == office_election.url %} current-page{% endif %}">
         <a class="ballot-nav__link-item" href="{{ office_election.url | prepend: site.baseurl }}" tabindex="{{ tabIndxVar}}">{{ office_election.title }}</a>
       </li>
       {% endfor %}


### PR DESCRIPTION
Changes condition for office election ballot-nav highlight to `page.url == office_election.url` so that offices highlight properly in the ballot-nav.

Honestly not sure what was going on in the case where they were all highlighting when the one "PENDING" measure was selected, but this seems to work, so great

on "PENDING" measure page, /referendum/oakland/2020-11-03/pending/
<img src="https://user-images.githubusercontent.com/20404311/74491821-996c9800-4e81-11ea-9d3a-156c73f8c0a3.png" width="300px">

on council-at-large page, /office/oakland/2020-11-03/city-council-at-large/
<img src="https://user-images.githubusercontent.com/20404311/74491862-c325bf00-4e81-11ea-897d-0e81aa06db8c.png" width="300px">