### PR TITLE
show March 2020 totals and link landing page to March 2020 election page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@ header: Track the money in Oakland elections
 ---
 
 {% assign oakland_total_funds = 0 %}
-{% for source in site.data.totals.oakland-2018 %}
+{% for source in site.data.totals.oakland-march-2020 %}
   {% assign oakland_total_funds = oakland_total_funds | plus: source[1] %}
 {% endfor %}
 
 {% capture hero-cta %}
 <div class="hero__cta-container">
-  <div class="hero__cta"><a class="btn" href="{{ site.baseurl }}{% link _office_elections/oakland/2018-11-06/mayor.md %}">Follow the money</a></div>
+  <div class="hero__cta"><a class="btn" href="{{ site.baseurl }}{% link _elections/oakland/2020-03-03.md %}">Follow the money</a></div>
 </div>
 {% endcapture %}
 
@@ -49,7 +49,7 @@ header: Track the money in Oakland elections
           <li>Are the sources of political spending local?</li>
         </ul>
         <div class="hero__funds__raised__header">
-          <h2>Total contributions flowing into Oakland’s 2018 Election:</h2>
+          <h2>Total contributions flowing into Oakland’s March 2020 Election:</h2>
         </div>
         <div class="hero__funds_raised__total">
           {{ oakland_total_funds | dollars }}


### PR DESCRIPTION
This work resolves #329 and (partly) #338

This PR links the landing page to the upcoming March 2020 Oakland election, and changes the landing page to show the total contributions for that election. Merging this PR marks the first release of the 2020 site!


### Previews

Large screens

Updated landing page total
![Screen Shot 2020-02-15 at 11 44 17 AM](https://user-images.githubusercontent.com/20404311/74594370-6db8f180-4fea-11ea-8b59-2cc55ff54e56.png)

Election-wide finance page that the landing page links to
![Screenshot_2020-02-15 Oakland March 3rd, 2020 Special Election](https://user-images.githubusercontent.com/20404311/74594372-73aed280-4fea-11ea-9af4-c7afd28f55e5.png)
