### PR TITLE
Use election.title to match ballot year in ballot-nav

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -1,7 +1,7 @@
 {% assign locality = include.locality %}
 {% assign tabIndxVar = 4 %}
 {% assign election_year = ballot.election | slice: 0, 4 %}
-{% assign ballots = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.election contains election_year' %}
+{% assign ballots = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.title contains election_year' %}
 
 <nav class="ballot-nav">
   <h3 class="ballot-nav__locality-heading">{{ locality.name | escape }}</h3>


### PR DESCRIPTION
This is a quick fix for the as-yet-unaccounted-for outage of 2020-03-23.

The `where_exp` in the ballot-nav that pulls all the ballots for the year stopped working.

This PR changes the `where_exp` to match on `ballot.title`, which contains a long title like "Oakland March 3rd, 2020 Special Election", instead of `ballot.election`, which contains a date like `2020-03-03`.

This is not a good solution for even the near term. At tomorrow's meeting, evening of Tuesday 3/24/2020, we will discuss a solution to get data from the backend that does not require this brittle where_exp.

Currently, an election file, such as, _elections/oakland/2020-03-03.md, looks like:
```
---
title: Oakland March 3rd, 2020 Special Election
locality: oakland
election: 2020-03-03
office_elections: []
referendums:
- _referendums/oakland/2020-03-03/oakland-parks-and-recreation-preservation-litter-reduction-and-homelessness-support-act.md
- _referendums/oakland/2020-03-03/official-city-newspaper.md
- _referendums/oakland/2020-03-03/increase-appropriations-limit.md
---
```

#### Before ☹️ 
![Screen Shot 2020-03-23 at 4 13 54 PM](https://user-images.githubusercontent.com/20404311/77373065-748efe80-6d24-11ea-90e4-3f9bcebbb0d7.png)

#### After 😄 
![Screen Shot 2020-03-23 at 4 13 28 PM](https://user-images.githubusercontent.com/20404311/77373071-7953b280-6d24-11ea-9cf8-9544d57c4e4a.png)
