### PR TITLE
Flip dates in navbar

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -1,7 +1,7 @@
 {% assign locality = include.locality %}
 {% assign tabIndxVar = 4 %}
 {% assign election_year = ballot.election | slice: 0, 4 %}
-{% assign ballots = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.title contains election_year' %}
+{% assign ballots = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.title contains election_year' | reverse %}
 
 <nav class="ballot-nav">
   <h3 class="ballot-nav__locality-heading">{{ locality.name | escape }}</h3>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ header: Track the money in Oakland elections
 
 {% capture hero-cta %}
 <div class="hero__cta-container">
-  <div class="hero__cta"><a class="btn" href="{{ site.baseurl }}{% link _elections/oakland/2020-03-03.md %}">Follow the money</a></div>
+  <div class="hero__cta"><a class="btn" href="{{ site.baseurl }}{% link _elections/oakland/2020-11-03.md %}">Follow the money</a></div>
 </div>
 {% endcapture %}
 


### PR DESCRIPTION
This work resolves #354.

Flips the order of the two elections in the sidebar. Not sure if this is the kosher way of solving it (e.g. if it's January, then we probably want March on top). Longer term solution is probably to have separate "Upcoming elections" and "Past elections" in the side bar but I decided to avoid tackling that for now.

Also figured that the button on the homepage should take you to the november election. Afaict, there's no functional difference since the main pane of the election page looks like placeholder.

### Previews
<img width="1440" alt="Screen Shot 2020-03-24 at 8 06 29 PM" src="https://user-images.githubusercontent.com/16271389/77497639-0f620880-6e0b-11ea-9572-1c0cded48af8.png">
