### PR TITLE
election overview

### DIFF
--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -1,0 +1,20 @@
+<div class="election-summary">
+  <section class="l-section election-summary__total">
+    <div class="election-summary__total-header">Total contributions reported for this election</div>
+    <div class="election-summary__total-amount">{{data_totals['Total'] | dollars}}</div>
+  </section>
+
+  <section class="l-section">
+    <div class="l-section__content">
+      <h2>Top 3 Most Expensive Races</h2>
+    </div>
+    <div class="l-section__content">
+      {% for race in data_totals['most_expensive_races'] %}
+        <div>
+          <a href="/{{race['type']}}/{{ballot.locality}}/{{ballot.slug}}/{{race['slug']}}/">{{race['title']}}</a>
+          <span class="election-summary__race-amount">{{race['amount'] | dollars}}</span>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+</div>

--- a/_layouts/ballot.html
+++ b/_layouts/ballot.html
@@ -10,7 +10,7 @@ layout: default
 
 {% capture body %}
 <header>
-  <h1>Data for All Upcoming Races</h1>
+  <h1>Data for All Upcoming Races in {{ballot.locality | capitalize}}</h1>
 </header>
 {% include election-summary.html %}
 {% endcapture %}

--- a/_layouts/ballot.html
+++ b/_layouts/ballot.html
@@ -6,8 +6,12 @@ layout: default
 
 {% assign today = site.time | date: "%Y-%m-%d" %}
 {% assign current_election = locality.current_election | date: "%Y-%m-%d" %}
+{% assign data_totals = site.data.totals[ballot.data_key] %}
 
 {% capture body %}
-<span>Election-wide finance data coming soon! Choose a ballot item from the navigation.</span>
+<header>
+  <h1>Data for All Upcoming Races</h1>
+</header>
+{% include election-summary.html %}
 {% endcapture %}
 {% include ballot-layout.html content=body ballot=ballot locality=locality %}

--- a/_layouts/ballot.html
+++ b/_layouts/ballot.html
@@ -6,7 +6,7 @@ layout: default
 
 {% assign today = site.time | date: "%Y-%m-%d" %}
 {% assign current_election = locality.current_election | date: "%Y-%m-%d" %}
-{% assign data_totals = site.data.totals[ballot.data_key] %}
+{% assign data_totals = site.data.totals[ballot.election_id] %}
 
 {% capture body %}
 <header>

--- a/_sass/_module.scss
+++ b/_sass/_module.scss
@@ -19,3 +19,4 @@
 @import 'module/page';
 @import 'module/referendum';
 @import 'module/tagline';
+@import 'module/election-summary';

--- a/_sass/module/_election-summary.scss
+++ b/_sass/module/_election-summary.scss
@@ -1,0 +1,23 @@
+.election-summary {
+  &__total {
+    text-align: center;
+    margin: 24px 0;
+
+    &-header {
+      text-transform: uppercase;
+      font-size: $h3-font-size;
+      margin-bottom: 12px;
+      color: $color-grey-3;
+    }
+
+    &-amount {
+      color: $color-grey-2;
+      font-size: $h1-font-size;
+      font-weight: $font-weight-bold;
+    }
+  }
+
+  &__race-amount {
+    float: right;
+  }
+}


### PR DESCRIPTION
This adds the top two sections for the election overview page as per [these mocks](https://projects.invisionapp.com/d/main#/console/15245532/316959430/preview) 

Not a pixel-pefect recreation, I tried to reuse existing header styles from other pages where appropriate and stick to existing variables as much as possible while still making it look good

Depends on both https://github.com/caciviclab/disclosure-backend-static/pull/223 and https://github.com/caciviclab/disclosure-backend-static/pull/222 for data generation

<img width="949" alt="Screen Shot 2020-03-31 at 12 47 46 AM" src="https://user-images.githubusercontent.com/16271389/78000896-d1248780-72e9-11ea-96a9-2b5749f3012f.png">


<img width="318" alt="Screen Shot 2020-03-31 at 12 51 06 AM" src="https://user-images.githubusercontent.com/16271389/78000930-daadef80-72e9-11ea-9410-6aff6e5b188a.png">
