### PR TITLE
make ballot-nav election date link to summary page

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -15,7 +15,7 @@
     {% assign office_elections = nav_ballot.office_elections %}
     {% capture summary_path %}/election/{{ nav_ballot.locality }}/{{ nav_ballot.election }}/{% endcapture %}
     <h3 class="ballot-nav__date-heading ballot-nav__group">
-      <a href="{{ summary_path | prepend: site.baseurl }}" class="ballot-nav__date-link{% if nav_ballot.election == path_end %} current-page{% endif %}">{{ nav_ballot.election | date: "%B %-d, %Y" }}</a>
+      <a href="{{ summary_path | prepend: site.baseurl }}" class="ballot-nav__link{% if nav_ballot.election == path_end %} current-page{% endif %}">{{ nav_ballot.election | date: "%B %-d, %Y" }}</a>
     </h3>
     {% if referendums and referendums != empty %}
     <div class="ballot-nav__group">
@@ -25,7 +25,7 @@
       {% assign tabIndxVar = tabIndxVar | plus:1 %}
       {% assign referendum = site.referendums | where: "path", ballot_item | first %}
       <li class="ballot-nav__list-item{% if page.url == referendum.url %} current-page{% endif %}">
-        <a class="ballot-nav__link-item" href="{{ referendum.url | prepend: site.baseurl }}" tabindex="{{ tabIndxVar }}">
+        <a class="ballot-nav__link" href="{{ referendum.url | prepend: site.baseurl }}" tabindex="{{ tabIndxVar }}">
           Measure {% if referendum.number %}{{ referendum.number }} {% endif %}
           <span class="ballot-nav__measure-title">{{ referendum.title | smartify }}</span>
         </a>
@@ -46,7 +46,7 @@
       {% assign tabIndxVar = tabIndxVar | plus:1 %}
       {% assign office_election = site.office_elections | where: "path", office_election_path | first %}
       <li class="ballot-nav__list-item{% if page.url == office_election.url %} current-page{% endif %}">
-        <a class="ballot-nav__link-item" href="{{ office_election.url | prepend: site.baseurl }}" tabindex="{{ tabIndxVar}}">{{ office_election.title }}</a>
+        <a class="ballot-nav__link" href="{{ office_election.url | prepend: site.baseurl }}" tabindex="{{ tabIndxVar}}">{{ office_election.title }}</a>
       </li>
       {% endfor %}
       </ul>

--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -9,12 +9,12 @@
     <h3 class="ballot-nav__section-heading">Upcoming Races</h3>
   </div>
   <section>
-    {% for ballot in ballots %}
-    {% assign referendums = ballot.referendums %}
-    {% assign office_elections = ballot.office_elections %}
-    {% capture summary_path %}/election/{{ ballot.locality }}/{{ ballot.election }}/{% endcapture %}
-    <h3 class="ballot-nav__date-heading ballot-nav__group">
-      <a href="{{ summary_path | prepend: site.baseurl }}">{{ ballot.election | date: "%B %-d, %Y" }}</a>
+    {% for nav_ballot in ballots %}
+    {% assign referendums = nav_ballot.referendums %}
+    {% assign office_elections = nav_ballot.office_elections %}
+    {% capture summary_path %}/election/{{ nav_ballot.locality }}/{{ nav_ballot.election }}/{% endcapture %}
+    <h3 class="ballot-nav__date-heading ballot-nav__group{% if nav_ballot.election == ballot.election %} current-page{% endif %}">
+      <a href="{{ summary_path | prepend: site.baseurl }}">{{ nav_ballot.election | date: "%B %-d, %Y" }}</a>
     </h3>
     {% if referendums and referendums != empty %}
     <div class="ballot-nav__group">

--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -1,6 +1,7 @@
 {% assign locality = include.locality %}
 {% assign tabIndxVar = 4 %}
 {% assign election_year = ballot.election | slice: 0, 4 %}
+{% assign path_end = page.url | split: "/" | last %}
 {% assign ballots = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.title contains election_year' | reverse %}
 
 <nav class="ballot-nav">
@@ -13,8 +14,8 @@
     {% assign referendums = nav_ballot.referendums %}
     {% assign office_elections = nav_ballot.office_elections %}
     {% capture summary_path %}/election/{{ nav_ballot.locality }}/{{ nav_ballot.election }}/{% endcapture %}
-    <h3 class="ballot-nav__date-heading ballot-nav__group{% if nav_ballot.election == ballot.election %} current-page{% endif %}">
-      <a href="{{ summary_path | prepend: site.baseurl }}" class="ballot-nav__date-link">{{ nav_ballot.election | date: "%B %-d, %Y" }}</a>
+    <h3 class="ballot-nav__date-heading ballot-nav__group">
+      <a href="{{ summary_path | prepend: site.baseurl }}" class="ballot-nav__date-link{% if nav_ballot.election == path_end %} current-page{% endif %}">{{ nav_ballot.election | date: "%B %-d, %Y" }}</a>
     </h3>
     {% if referendums and referendums != empty %}
     <div class="ballot-nav__group">

--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -12,7 +12,10 @@
     {% for ballot in ballots %}
     {% assign referendums = ballot.referendums %}
     {% assign office_elections = ballot.office_elections %}
-    <h3 class="ballot-nav__date-heading ballot-nav__group">{{ ballot.election | date: "%B %-d, %Y" }}</h3>
+    {% capture summary_path %}/election/{{ ballot.locality }}/{{ ballot.election }}/{% endcapture %}
+    <h3 class="ballot-nav__date-heading ballot-nav__group">
+      <a href="{{ summary_path | prepend: site.baseurl }}">{{ ballot.election | date: "%B %-d, %Y" }}</a>
+    </h3>
     {% if referendums and referendums != empty %}
     <div class="ballot-nav__group">
       <h4 class="ballot-nav__section-heading">{% include referendum_measure_heading.html referendum_measure_display=locality.referendum_measure_display %}</h4>

--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -14,7 +14,7 @@
     {% assign office_elections = nav_ballot.office_elections %}
     {% capture summary_path %}/election/{{ nav_ballot.locality }}/{{ nav_ballot.election }}/{% endcapture %}
     <h3 class="ballot-nav__date-heading ballot-nav__group{% if nav_ballot.election == ballot.election %} current-page{% endif %}">
-      <a href="{{ summary_path | prepend: site.baseurl }}">{{ nav_ballot.election | date: "%B %-d, %Y" }}</a>
+      <a href="{{ summary_path | prepend: site.baseurl }}" class="ballot-nav__date-link">{{ nav_ballot.election | date: "%B %-d, %Y" }}</a>
     </h3>
     {% if referendums and referendums != empty %}
     <div class="ballot-nav__group">

--- a/_sass/module/_ballot-nav.scss
+++ b/_sass/module/_ballot-nav.scss
@@ -13,7 +13,7 @@ $ballot-nav-border: 2px $color-grey-4-5 solid;
 }
 
 .ballot-nav__locality-heading,
-.ballot-nav__date-heading,
+.ballot-nav__date-link,
 .ballot-nav__section-heading,
 .ballot-nav__link-item {
   padding-left: $spacing-base * 2;
@@ -23,8 +23,6 @@ $ballot-nav-border: 2px $color-grey-4-5 solid;
 .ballot-nav__locality-heading,
 .ballot-nav__date-heading {
   margin: 0;
-  padding-top: $spacing-base * 2;
-  padding-bottom: $spacing-base * 2;
   color: $brand-color; // TODO : make $color-navy a $heading-color
 }
 
@@ -33,11 +31,21 @@ $ballot-nav-border: 2px $color-grey-4-5 solid;
   color: $heading-color--light;
 }
 
-.ballot-nav__link-item {
+.ballot-nav__link-item,
+.ballot-nav__date-link {
   display: block;
+  text-decoration: none;
+}
+
+.ballot-nav__link-item {
   padding-top: $spacing-base;
   padding-bottom: $spacing-base;
-  text-decoration: none;
+}
+
+.ballot-nav__locality-heading,
+.ballot-nav__date-link {
+  padding-top: $spacing-base * 2;
+  padding-bottom: $spacing-base * 2;
 }
 
 .ballot-nav__list-item:last-child {

--- a/_sass/module/_ballot-nav.scss
+++ b/_sass/module/_ballot-nav.scss
@@ -13,9 +13,8 @@ $ballot-nav-border: 2px $color-grey-4-5 solid;
 }
 
 .ballot-nav__locality-heading,
-.ballot-nav__date-link,
 .ballot-nav__section-heading,
-.ballot-nav__link-item {
+.ballot-nav__link {
   padding-left: $spacing-base * 2;
   padding-right: $spacing-base * 2;
 }
@@ -31,19 +30,16 @@ $ballot-nav-border: 2px $color-grey-4-5 solid;
   color: $heading-color--light;
 }
 
-.ballot-nav__link-item,
-.ballot-nav__date-link {
+.ballot-nav__link {
   display: block;
+  padding-top: $spacing-base;
+  padding-bottom: $spacing-base;
   text-decoration: none;
 }
 
-.ballot-nav__link-item {
-  padding-top: $spacing-base;
-  padding-bottom: $spacing-base;
-}
-
 .ballot-nav__locality-heading,
-.ballot-nav__date-link {
+.ballot-nav__date-link,
+.ballot-nav__date-heading .ballot-nav__link {
   padding-top: $spacing-base * 2;
   padding-bottom: $spacing-base * 2;
 }
@@ -76,6 +72,6 @@ $ballot-nav-border: 2px $color-grey-4-5 solid;
   font-size: $small-font-size;
 }
 
-.ballot-nav__link-item:hover {
+.ballot-nav__link:hover {
   background-color: $color-gold;
 }


### PR DESCRIPTION
This work resolves #357 

Makes election dates in ballot nav into links to election summary page for date.


### Previews
![Screen Shot 2020-04-01 at 8 50 49 PM](https://user-images.githubusercontent.com/20404311/78209070-ebca3e00-745a-11ea-9104-7212ee68f756.png)
