### PR TITLE
Update landing page link to point to November election

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ header: Track the money in Oakland elections
         </h4>
         <h1 class="hero__hed">{{ page.header | escape }}</h1>
         <div>
-          <a class="btn landing__btn" href="{{ site.baseurl }}{% link _elections/oakland/2020-03-03.md %}">Follow the money</a>
+          <a class="btn landing__btn" href="{{ site.baseurl }}{% link _elections/oakland/2020-11-03.md %}">Follow the money</a>
         </div>
     </div>
     <div class="hero__table-container">


### PR DESCRIPTION
This work resolves #359.