### PR TITLE
Use new totals.json location for landing page data

### DIFF
--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -1,7 +1,7 @@
 <div class="election-summary">
   <section class="l-section election-summary__total">
     <div class="election-summary__total-header">Total contributions reported for this election</div>
-    <div class="election-summary__total-amount">{{data_totals['Total'] | dollars}}</div>
+    <div class="election-summary__total-amount">{{data_totals['total_contributions'] | dollars}}</div>
   </section>
 
   <section class="l-section">

--- a/index.html
+++ b/index.html
@@ -3,19 +3,11 @@ layout: default
 header: Track the money in Oakland elections
 ---
 
-{% assign oakland_march_total_funds = 0 %}
-{% for source in site.data.totals.oakland-march-2020 %}
-  {% assign oakland_march_total_funds = oakland_march_total_funds | plus: source[1] %}
-{% endfor %}
+{% assign oakland_march_total_funds = site.data.totals.oakland-march-2020.total_contributions %}
+{% assign oakland_march_residents_percentage = site.data.totals.oakland-march-2020.total_contributions_by_source['Within Oakland'] | divided_by: oakland_march_total_funds%}
 
-{% assign oakland_march_residents_percentage = site.data.totals.oakland-march-2020['Within Oakland'] | divided_by: oakland_march_total_funds%}
-
-{% assign oakland_total_funds = 0 %}
-{% for source in site.data.totals.oakland-2020 %}
-  {% assign oakland_total_funds = oakland_total_funds | plus: source[1] %}
-{% endfor %}
-
-{% assign oakland_residents_percentage = site.data.totals.oakland-2020['Within Oakland'] | divided_by: oakland_total_funds%}
+{% assign oakland_total_funds = site.data.totals.oakland-2020.total_contributions %}
+{% assign oakland_residents_percentage = site.data.totals.oakland-2020.total_contributions_by_source['Within Oakland'] | divided_by: oakland_total_funds %}
 
 {% assign ie_placeholder_text = 'No independent expenditures reported' %}
 


### PR DESCRIPTION
We moved the contributions by source ("Within Oakland", etc.) into an
object called `total_contributions_by_source`. Also, now there is a
`total_contributions` field so we don't need to do the summation of all
the contributions by source anymore.