### PR TITLE
fixes issue 366 & 367. Broken footer link and incorrect header text

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
             <li class="footer__nav-item"><a href="{{ site.baseurl }}/about/">About</a></li>
             <li class="footer__nav-item"><a href="{{ site.baseurl }}/press/">Press</a></li>
             <li class="footer__nav-item"><a href="{{ site.baseurl }}/faq/">FAQ</a></li>
-            <li class="footer__nav-item"><a href="https://caciviclab.org/opendisclosure/">Join us</a></li>
+            <li class="footer__nav-item"><a href="https://openoakland.org/">Join us</a></li>
             <li class="footer__nav-item"><a href="https://github.com/caciviclab/odca-jekyll#license">Open source</a></li>
             <li class="footer__nav-item"><a href="https://registertovote.ca.gov/">Register to vote</a></li>
           </ul>

--- a/_layouts/ballot.html
+++ b/_layouts/ballot.html
@@ -5,12 +5,12 @@ layout: default
 {% assign locality = site.localities | where: 'slug', ballot.locality | first %}
 
 {% assign today = site.time | date: "%Y-%m-%d" %}
-{% assign current_election = locality.current_election | date: "%Y-%m-%d" %}
+{% assign current_election = locality.current_election | date: "%B %-d, %Y" %}
 {% assign data_totals = site.data.totals[ballot.election_id] %}
 
 {% capture body %}
 <header>
-  <h1>Data for All Upcoming Races in {{ballot.locality | capitalize}}</h1>
+  <h1>Data for {{ballot.locality | capitalize}} Election on {{ballot.election | date: "%B %-d, %Y"}}</h1>
 </header>
 {% include election-summary.html %}
 {% endcapture %}


### PR DESCRIPTION
This work resolves #366  & #367 .

#366  : Went in and updated the broken link to caciviclab.org to point to open oaklands homepage

#367  : Also changed intor text of election/oakland/ pages to read
Data for Oakland Election on...
instead of
Data for All Upcoming Races in...
