### PR TITLE
Add 3 more sections to election summary page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,7 @@ _ballots
 _elections
 _candidates
 _committees
-<<<<<<< HEAD
 _data
-=======
-_data/
->>>>>>> gulp pull new _data/elections/ files, and ignore them
 .DS_Store
 _includes/svg
 .jekyll-cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@ _ballots
 _elections
 _candidates
 _committees
+<<<<<<< HEAD
 _data
+=======
+_data/
+>>>>>>> gulp pull new _data/elections/ files, and ignore them
 .DS_Store
 _includes/svg
 .jekyll-cache

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -20,6 +20,11 @@
   <section class="l-section">
     <div class="l-section_content">
       <h2>Who is contributing to races on this ballot?</h2>
+      {% for contribution_type in election_totals['contributions_by_type'] %}
+      <div>
+        <span>{{ contribution_type[0] }}: {{ contribution_type[1] }}</span>
+      </div>
+      {% endfor %}
     </div>
   </section>
   <section class="l-section">

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -17,7 +17,7 @@
     <div class="l-section__content">
       {% for race in data_totals['most_expensive_races'] %}
         <div>
-          <a href="/{{race['type']}}/{{ballot.locality}}/{{ballot.slug}}/{{race['slug']}}/">{{race['title']}}</a>
+          <a href="/{{race.type}}/{{ballot.locality}}/{{ballot.slug}}/{{race.slug}}/">{{race['title']}}</a>
           <span class="election-summary__race-amount">{{race['amount'] | dollars}}</span>
         </div>
       {% endfor %}
@@ -28,10 +28,10 @@
       <h2>Who is contributing to races on this ballot?</h2>
     </div>
     <div class="l-section__content">
-      {% for contribution_type in election_totals['contributions_by_type'] %}
-      {% assign amount = contribution_type[1] %}
-      {% assign type_name = contribution_type[0] %}
-      {% include money-bar.html label=type_name value=amount color="green" max=data_totals.total_contributions %}
+      {% for contribution_type in election_totals.contributions_by_type %}
+        {% assign amount = contribution_type[1] %}
+        {% assign type_name = contribution_type[0] %}
+        {% include money-bar.html label=type_name value=amount color="green" max=data_totals.total_contributions %}
       {% endfor %}
     </div>
   </section>
@@ -39,10 +39,34 @@
     <div class="l-section__content">
       <h2>Candidates with the largest proportion of small contributions (under $100)</h2>
     </div>
+    <div class="l-section__content">
+      <ul>
+        {% for candidate in election_totals.candidates_with_most_small_contributions %}
+        <li>
+          <span>
+            <a
+              href="{{ site.baseurl }}/{{ ballot.locality }}/{{ ballot.slug }}/{{ candidate.slug }}"
+            >{{ candidate.name }}</a>, {{ candidate.office_title }}
+          </span>
+          <span>{{ candidate.small_contribution_percent | times: 100 }}%</span>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
   </section>
   <section class="l-section">
     <div class="l-section__content">
       <h2>Top 5 spenders who have made the most large contributions (over $100)</h2>
+    </div>
+    <div class="l-section__content">
+      <ul>
+        {% for spender in election_totals.top_spenders %}
+        <li>
+          <span>{{ spender.name }}</span>
+          <span>{{ spender.total_contributions }} contributions in {{ ballot.election | date: "%Y" }}</span>
+        </li>
+        {% endfor %}
+      </ul>
     </div>
   </section>
   <section class="l-section">

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -1,3 +1,9 @@
+{% assign max = 0 %}
+{% for contribution_type in election_totals['contributions_by_type'] %}
+  {% assign amount = contribution_type[1] %}
+  {% assign max = max | plus: amount %}
+{% endfor %}
+
 <div class="election-summary">
   <section class="l-section election-summary__total">
     <div class="election-summary__total-header">Total contributions reported for this election</div>
@@ -18,27 +24,29 @@
     </div>
   </section>
   <section class="l-section">
-    <div class="l-section_content">
+    <div class="l-section__content">
       <h2>Who is contributing to races on this ballot?</h2>
+    </div>
+    <div class="l-section__content">
       {% for contribution_type in election_totals['contributions_by_type'] %}
-      <div>
-        <span>{{ contribution_type[0] }}: {{ contribution_type[1] }}</span>
-      </div>
+      {% assign amount = contribution_type[1] %}
+      {% assign type_name = contribution_type[0] %}
+      {% include money-bar.html label=type_name value=amount color="green" max=data_totals.total_contributions %}
       {% endfor %}
     </div>
   </section>
   <section class="l-section">
-    <div class="l-section_content">
+    <div class="l-section__content">
       <h2>Candidates with the largest proportion of small contributions (under $100)</h2>
     </div>
   </section>
   <section class="l-section">
-    <div class="l-section_content">
+    <div class="l-section__content">
       <h2>Top 5 spenders who have made the most large contributions (over $100)</h2>
     </div>
   </section>
   <section class="l-section">
-    <div class="l-section_content">
+    <div class="l-section__content">
       <h2>Where is the money coming from?</h2>
     </div>
   </section>

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -17,4 +17,24 @@
       {% endfor %}
     </div>
   </section>
+  <section class="l-section">
+    <div class="l-section_content">
+      <h2>Who is contributing to races on this ballot?</h2>
+    </div>
+  </section>
+  <section class="l-section">
+    <div class="l-section_content">
+      <h2>Candidates with the largest proportion of small contributions (under $100)</h2>
+    </div>
+  </section>
+  <section class="l-section">
+    <div class="l-section_content">
+      <h2>Top 5 spenders who have made the most large contributions (over $100)</h2>
+    </div>
+  </section>
+  <section class="l-section">
+    <div class="l-section_content">
+      <h2>Where is the money coming from?</h2>
+    </div>
+  </section>
 </div>

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -1,7 +1,7 @@
 <div class="election-summary">
   <section class="l-section election-summary__total">
     <div class="election-summary__total-header">Total contributions reported for this election</div>
-    <div class="election-summary__total-amount">{{ data_totals['total_contributions'] | dollars }}</div>
+    <div class="election-summary__total-amount">{{ data_totals.total_contributions | dollars }}</div>
   </section>
 
   <section class="l-section">
@@ -9,9 +9,9 @@
       <h2>Top 3 Most Expensive Races</h2>
     </div>
     <div class="l-section__content">
-      {% for race in data_totals['most_expensive_races'] %}
+      {% for race in data_totals.most_expensive_races %}
         <div>
-          <a href="/{{race.type}}/{{ballot.locality}}/{{ballot.slug}}/{{race.slug}}/">{{race['title']}}</a>
+          <a href="/{{race.type}}/{{ballot.locality}}/{{ballot.slug}}/{{race.slug}}/">{{ race.title }}</a>
           <span class="election-summary__race-amount">{{ race.amount | dollars }}</span>
         </div>
       {% endfor %}

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -61,7 +61,7 @@
   </section>
   <section class="l-section">
     <div class="l-section__content">
-      <h2>Top 5 spenders who have made the most large contributions (over $100)</h2>
+      <h2>Top 5 spenders who have made the most large contributions</h2>
     </div>
     <div class="l-section__content">
       <ul class="no-bullet-list">

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -1,14 +1,3 @@
-{% assign max = 0 %}
-{% for contribution_type in election_totals['contributions_by_type'] %}
-  {% assign amount = contribution_type[1] %}
-  {% assign max = max | plus: amount %}
-{% endfor %}
-
-{% for source in election_totals.total_contributions_by_source %}
-  {% assign amount = contribution_type[1] %}
-  {% assign max = max | plus: amount %}
-{% endfor %}
-
 <div class="election-summary">
   <section class="l-section election-summary__total">
     <div class="election-summary__total-header">Total contributions reported for this election</div>

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -23,7 +23,7 @@
       {% for race in data_totals['most_expensive_races'] %}
         <div>
           <a href="/{{race.type}}/{{ballot.locality}}/{{ballot.slug}}/{{race.slug}}/">{{race['title']}}</a>
-          <span class="election-summary__race-amount">{{race['amount'] | dollars}}</span>
+          <span class="election-summary__race-amount">{{ race.amount | dollars }}</span>
         </div>
       {% endfor %}
     </div>
@@ -64,11 +64,11 @@
       <h2>Top 5 spenders who have made the most large contributions (over $100)</h2>
     </div>
     <div class="l-section__content">
-      <ul>
+      <ul class="no-bullet-list">
         {% for spender in election_totals.top_spenders %}
-        <li>
-          <span>{{ spender.name }}</span>
-          <span>{{ spender.total_contributions }} contributions in {{ ballot.election | date: "%Y" }}</span>
+        <li class="grid grid--full">
+          <span class="grid-col-10">{{ spender.name }}</span>
+          <span class="grid-col-2 align-right">{{ spender.total_spending | dollars }}</span>
         </li>
         {% endfor %}
       </ul>
@@ -79,9 +79,9 @@
       <h2>Where is the money coming from?</h2>
     </div>
     <div class="l-section__content">
-      <ul>
+      <ul class="no-bullet-list">
         {% for source in election_totals.total_contributions_by_source %}
-        <li>
+        <li class="grid">
           {% assign place=source[0] %}
           {% assign amount=source[1] %}
           {% include money-bar.html label=place value=amount color="green" max=data_totals.total_contributions %}

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -45,15 +45,15 @@
       <h2>Candidates with the largest proportion of small contributions (under $100)</h2>
     </div>
     <div class="l-section__content">
-      <ul>
-        {% for candidate in election_totals.candidates_with_most_small_contributions %}
-        <li>
-          <span>
+      <ul class="no-bullet-list">
+        {% for candidate in election_totals.largest_small_proportion %}
+        <li class="grid grid--full">
+          <span class="grid-col-11">
             <a
-              href="{{ site.baseurl }}/{{ ballot.locality }}/{{ ballot.slug }}/{{ candidate.slug }}"
-            >{{ candidate.name }}</a>, {{ candidate.office_title }}
+              href="{{ site.baseurl }}/candidate/{{ ballot.locality }}/{{ ballot.slug }}/{{ candidate.slug }}"
+            >{{ candidate.candidate }}</a>, {{ candidate.office_title }}
           </span>
-          <span>{{ candidate.small_contribution_percent | times: 100 }}%</span>
+          <span class="grid-col-1 align-right">{{ candidate.proportion | times: 100 | round: 1 }}%</span>
         </li>
         {% endfor %}
       </ul>
@@ -82,10 +82,9 @@
       <ul>
         {% for source in election_totals.total_contributions_by_source %}
         <li>
-          <span>{{ source[0] }}</span>
-          <span>{{ source[1] }}</span>
+          {% assign place=source[0] %}
           {% assign amount=source[1] %}
-          {% include money-bar.html label=type_name value=amount color="green" max=data_totals.total_contributions %}
+          {% include money-bar.html label=place value=amount color="green" max=data_totals.total_contributions %}
         </li>
         {% endfor %}
       </ul>

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -4,10 +4,15 @@
   {% assign max = max | plus: amount %}
 {% endfor %}
 
+{% for source in election_totals.total_contributions_by_source %}
+  {% assign amount = contribution_type[1] %}
+  {% assign max = max | plus: amount %}
+{% endfor %}
+
 <div class="election-summary">
   <section class="l-section election-summary__total">
     <div class="election-summary__total-header">Total contributions reported for this election</div>
-    <div class="election-summary__total-amount">{{data_totals['total_contributions'] | dollars}}</div>
+    <div class="election-summary__total-amount">{{ data_totals['total_contributions'] | dollars }}</div>
   </section>
 
   <section class="l-section">
@@ -72,6 +77,18 @@
   <section class="l-section">
     <div class="l-section__content">
       <h2>Where is the money coming from?</h2>
+    </div>
+    <div class="l-section__content">
+      <ul>
+        {% for source in election_totals.total_contributions_by_source %}
+        <li>
+          <span>{{ source[0] }}</span>
+          <span>{{ source[1] }}</span>
+          {% assign amount=source[1] %}
+          {% include money-bar.html label=type_name value=amount color="green" max=data_totals.total_contributions %}
+        </li>
+        {% endfor %}
+      </ul>
     </div>
   </section>
 </div>

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -6,7 +6,7 @@
 
   <section class="l-section">
     <div class="l-section__content">
-      <h2>Top 3 Most Expensive Races</h2>
+      <h3>Top 3 Most Expensive Races</h3>
     </div>
     <div class="l-section__content">
       {% for race in data_totals.most_expensive_races %}
@@ -19,7 +19,7 @@
   </section>
   <section class="l-section">
     <div class="l-section__content">
-      <h2>Who is contributing to races on this ballot?</h2>
+      <h3>Who is contributing to races on this ballot?</h3>
     </div>
     <div class="l-section__content">
       {% for contribution_type in election_totals.contributions_by_type %}
@@ -31,7 +31,7 @@
   </section>
   <section class="l-section">
     <div class="l-section__content">
-      <h2>Candidates with the largest proportion of small contributions (under $100)</h2>
+      <h3>Candidates with the largest proportion of small contributions (under $100)</h3>
     </div>
     <div class="l-section__content">
       <ul class="no-bullet-list">
@@ -50,7 +50,7 @@
   </section>
   <section class="l-section">
     <div class="l-section__content">
-      <h2>Where is the money coming from?</h2>
+      <h3>Where is the money coming from?</h3>
     </div>
     <div class="l-section__content">
       <ul class="no-bullet-list">

--- a/_includes/election-summary.html
+++ b/_includes/election-summary.html
@@ -61,21 +61,6 @@
   </section>
   <section class="l-section">
     <div class="l-section__content">
-      <h2>Top 5 spenders who have made the most large contributions</h2>
-    </div>
-    <div class="l-section__content">
-      <ul class="no-bullet-list">
-        {% for spender in election_totals.top_spenders %}
-        <li class="grid grid--full">
-          <span class="grid-col-10">{{ spender.name }}</span>
-          <span class="grid-col-2 align-right">{{ spender.total_spending | dollars }}</span>
-        </li>
-        {% endfor %}
-      </ul>
-    </div>
-  </section>
-  <section class="l-section">
-    <div class="l-section__content">
       <h2>Where is the money coming from?</h2>
     </div>
     <div class="l-section__content">

--- a/_layouts/ballot.html
+++ b/_layouts/ballot.html
@@ -7,6 +7,7 @@ layout: default
 {% assign today = site.time | date: "%Y-%m-%d" %}
 {% assign current_election = locality.current_election | date: "%B %-d, %Y" %}
 {% assign data_totals = site.data.totals[ballot.election_id] %}
+{% assign election_totals = site.data.elections[ballot.election] %}
 
 {% capture body %}
 <header>

--- a/_layouts/ballot.html
+++ b/_layouts/ballot.html
@@ -7,7 +7,7 @@ layout: default
 {% assign today = site.time | date: "%Y-%m-%d" %}
 {% assign current_election = locality.current_election | date: "%B %-d, %Y" %}
 {% assign data_totals = site.data.totals[ballot.election_id] %}
-{% assign election_totals = site.data.elections[ballot.election] %}
+{% assign election_totals = site.data.elections[ballot.locality][ballot.election] %}
 
 {% capture body %}
 <header>

--- a/_layouts/ballot.html
+++ b/_layouts/ballot.html
@@ -11,7 +11,7 @@ layout: default
 
 {% capture body %}
 <header>
-  <h1>Data for {{ballot.locality | capitalize}} Election on {{ballot.election | date: "%B %-d, %Y"}}</h1>
+  <h2>Data for {{ballot.locality | capitalize}} Election on {{ballot.election | date: "%B %-d, %Y"}}</h2>
 </header>
 {% include election-summary.html %}
 {% endcapture %}

--- a/_sass/base/_elements.scss
+++ b/_sass/base/_elements.scss
@@ -46,6 +46,12 @@ nav {
   }
 }
 
+.no-bullet-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 table {
   border-collapse: collapse;
 }

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -112,3 +112,7 @@ a:hover {
   font-size: $small-font-size;
   font-style: italic;
 }
+
+.align-right {
+  text-align: right;
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ gulp.task('clean', function () {
     '_referendums',
     '_data/candidates',
     '_data/committees',
+    '_data/elections',
     '_data/referendum_opposing',
     '_data/referendum_supporting',
     '_data/stats.json',
@@ -34,6 +35,11 @@ gulp.task('pull:elections', function () {
   return gulp.src(dataDir('_elections', '**', '*.md'))
     .pipe(gulp.dest('_elections'));
 });
+
+gulp.task('pull:elections-totals', function () {
+  return gulp.src(dataDir('_data', 'elections', '**', '*.json'))
+    .pipe(gulp.dest('_data/elections'));
+})
 
 gulp.task('pull:referendums', function () {
   return gulp.src(dataDir('_referendums', '**', '*.md'))
@@ -93,6 +99,7 @@ gulp.task('pull:totals', function () {
 gulp.task('pull', gulp.parallel(
   'pull:ballots',
   'pull:elections',
+  'pull:elections-totals',
   'pull:candidates',
   'pull:candidates-finance',
   'pull:committees',


### PR DESCRIPTION
Partial resolution of #364 

Adds
- **Who is contributing to races on this ballot?**
- **Candidates with the largest proportion of small contributions (under $100)**
- **Where is the money coming from?**
to the election summary page.

Does not add **Top 5 Spenders**. We're waiting for the data from the backend team for that one.


### Previews

Large screens

![Screenshot_2020-07-14 Oakland November 3rd, 2020 General Election](https://user-images.githubusercontent.com/20404311/87498423-9af6e380-c60c-11ea-8a93-f31abbd1f05e.png)



Small screens

<img width="300" src="https://user-images.githubusercontent.com/20404311/87498936-e52c9480-c60d-11ea-8e37-f9eb70b61ad1.png" />
