### PR TITLE
added search link to header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,6 +18,7 @@
           </span>
         </label>
         <div class="header-nav__items">
+          <a class="header-nav__link-item" href="{{ site.baseurl }}/search/">Search</a>
           <a class="header-nav__link-item" href="{{ site.baseurl }}/press/">Press</a>
           <a class="header-nav__link-item" href="{{ site.baseurl }}/about/">About</a>
           <a class="header-nav__link-item" href="{{ site.baseurl }}/faq/">FAQ</a>


### PR DESCRIPTION
This work resolves #395 

To test: 
* Visit the site, see that the "search" link appears in the header 
* Click the link and see that it brings you to the search page

Please include a description of the work.

* Added a link to the header to direct users to the search page 

<!-- you may remove this section below if the PR does not include any visual changes -->
### Previews

Large screens
<img width="1266" alt="Screen Shot 2020-08-11 at 8 24 10 PM" src="https://user-images.githubusercontent.com/13214848/89971618-a2f87200-dc10-11ea-9197-8dadf9632d19.png">


Small screens
<img width="297" alt="Screen Shot 2020-08-11 at 8 24 33 PM" src="https://user-images.githubusercontent.com/13214848/89971636-aee43400-dc10-11ea-9899-d4c6cc349bb4.png">

