### PR TITLE
Change link to contributions table from comittee name to more descriptive link

### DIFF
--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -47,12 +47,15 @@ First we calculate the maximum for the money bar.
   {% assign name = committee.Filer_NamL | default: committee.name %}
 
   {% if filer_id != "pending" and filer_id != "Pending" and filer_id != "PENDING" %}
-  <div><a href="{{ site.baseurl }}/committee/{{ filer_id }}/">{{ name | smartify }}</a></div>
-  {% if money > 0 %}
-    <div>{{ money | dollars }}</div>
-    {% include money-bar.html value=money color=include.color max=max %}
-  {% else %}
-    <div class="note">No expenditures have been reported by this committee</div>
-  {% endif %}
+  <div class="committee__support_oppose">
+    <div>{{ name | smartify }}</div>
+    <a href="{{ site.baseurl }}/committee/{{ filer_id }}/">See all contributions to this committee</a>
+    {% if money > 0 %}
+      <div>{{ money | dollars }}</div>
+      {% include money-bar.html value=money color=include.color max=max %}
+    {% else %}
+      <div class="note">No expenditures have been reported by this committee</div>
+    {% endif %}
+  </div>
   {% endif %}
 {% endfor %}

--- a/_sass/module/_referendum.scss
+++ b/_sass/module/_referendum.scss
@@ -30,3 +30,12 @@
     font-weight: $font-weight-normal;
   }
 }
+
+.committee__support_oppose {
+  margin-bottom: $spacing-base * 3;
+  a {
+    display: block;
+    margin-top: $spacing-base * 0.5;
+    margin-bottom: $spacing-base * 0.5;
+  }
+}

--- a/_sass/module/_referendum.scss
+++ b/_sass/module/_referendum.scss
@@ -33,6 +33,7 @@
 
 .committee__support_oppose {
   margin-bottom: $spacing-base * 3;
+
   a {
     display: block;
     margin-top: $spacing-base * 0.5;


### PR DESCRIPTION
This work resolves #350. 

The issue arose from the confusion that the current links from the committee headers are listed under "_Spending_ breakdown by committee" but link to a _contributions_ table. This clarifying text could solve that problem.

Very open to design/styling tweaks. 

### Large screen
<img width="918" alt="Screen Shot 2020-09-01 at 8 41 28 PM" src="https://user-images.githubusercontent.com/28023047/91929748-f2701200-ec93-11ea-82bf-1135a7b397a9.png">

### Small screen
<img width="499" alt="Screen Shot 2020-09-01 at 8 45 05 PM" src="https://user-images.githubusercontent.com/28023047/91929791-0ae02c80-ec94-11ea-9264-49270956e28e.png">
