### PR TITLE
Fix empty Top 3rd Party Spenders section on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,13 @@ layout: default
 header: Track the money in Oakland elections
 ---
 
-{% assign oakland_march_total_funds = site.data.totals.oakland-march-2020.total_contributions %}
-{% assign oakland_march_residents_percentage = site.data.totals.oakland-march-2020.total_contributions_by_source['Within Oakland'] | divided_by: oakland_march_total_funds%}
+{% assign march_totals = site.data.elections.oakland['2020-03-03'] %}
+{% assign oakland_march_total_funds = march_totals.total_contributions %}
+{% assign oakland_march_residents_percentage = march_totals.total_contributions_by_source['Within Oakland'] | divided_by: oakland_march_total_funds %}
 
-{% assign oakland_total_funds = site.data.totals.oakland-2020.total_contributions %}
-{% assign oakland_residents_percentage = site.data.totals.oakland-2020.total_contributions_by_source['Within Oakland'] | divided_by: oakland_total_funds %}
+{% assign election_totals = site.data.elections.oakland['2020-11-03'] %}
+{% assign oakland_total_funds = election_totals.total_contributions %}
+{% assign oakland_residents_percentage = election_totals.total_contributions_by_source['Within Oakland'] | divided_by: oakland_total_funds %}
 
 {% assign ie_placeholder_text = 'No independent expenditures reported' %}
 
@@ -51,10 +53,10 @@ header: Track the money in Oakland elections
                 <tr>
                     <td class="hero__row__header">Top 3 third-party spenders (independent expenditures)</td>
                     <td class="hero__top-spenders">
-                      {% if site.data.totals.oakland-march-2020.largest_independent_expenditures != null %}
+                      {% if march_totals.largest_independent_expenditures[0] != null %}
                       <ul>
                         {% for expenditure in site.data.totals.oakland-march-2020.largest_independent_expenditures %}
-                        <li>{{ expenditure.Filer_NamL }}</li>
+                        <li>{{ expenditure.name }}</li>
                         {% endfor %}
                       </ul>
                       {% else %}
@@ -62,10 +64,10 @@ header: Track the money in Oakland elections
                       {% endif %}
                     </td>
                     <td class="hero__top-spenders">
-                      {% if site.data.totals.oakland-2020.largest_independent_expenditures != null %}
+                      {% if election_totals.largest_independent_expenditures[0] != null %}
                       <ul>
-                        {% for expenditure in site.data.totals.oakland-2020.largest_independent_expenditures %}
-                        <li>{{ expenditure.Filer_NamL }}</li>
+                        {% for expenditure in election_totals.largest_independent_expenditures %}
+                        <li>{{ expenditure.name }}</li>
                         {% endfor %}
                       </ul>
                       {% else %}


### PR DESCRIPTION
This work resolves #409 

**This PR depends on [PR #268](https://github.com/caciviclab/disclosure-backend-static/pull/268) from backend**

Fixes references to election-specific totals files and to keys in the totals files where top independent expenditures live. This will be ready to merge when the PR to add IEs for candidates is merged on the backend.


### Previews

Large screens

![Screen Shot 2020-09-15 at 10 01 15 PM](https://user-images.githubusercontent.com/20404311/93659394-8adaf600-f9f9-11ea-8251-76a8ee620a78.png)
