### PR TITLE
Add current.html to redirect to upcoming election

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem "jekyll-seo-tag"
   gem "jekyll-assets"
+  gem 'jekyll-redirect-from'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
       sprockets (>= 3.3, < 4.1.beta)
     jekyll-feed (0.10.0)
       jekyll (~> 3.3)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sanity (1.2.0)
       jekyll (~> 3.1)
     jekyll-sass-converter (1.5.2)
@@ -124,6 +126,7 @@ DEPENDENCIES
   jekyll (>= 3.7)
   jekyll-assets
   jekyll-feed (~> 0.6)
+  jekyll-redirect-from
   jekyll-seo-tag
   mini_magick
   neat

--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,7 @@ defaults:
 markdown: kramdown
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
 include:
   - .circleci # Include CircleCI config so gh-pages branch is ignored in CI
 

--- a/current.html
+++ b/current.html
@@ -1,0 +1,3 @@
+---
+redirect_to: /election/oakland/2020-11-03
+---


### PR DESCRIPTION
This work resolves #416 .

Adds **current.html** and the [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) plugin. **opendisclosure.io/current** is set to redirect to **opendisclosure.io/election/oakland/2020-11-03**. current.html should be updated every election year to redirect to that year's next upcoming election.