### PR TITLE
Updated team members on about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -19,6 +19,8 @@ All development on Open Disclosure happens publicly on [Github](https://github.c
 - Sarah Seiter (2014-2020)
 - Suzanne Doran (2016-2020)
 - Tom Dooner (2014-2020)
+- Karen Ivy (2020-2020)
+
 
 ### Open Disclosure Alumni
 

--- a/about.md
+++ b/about.md
@@ -15,6 +15,8 @@ All development on Open Disclosure happens publicly on [Github](https://github.c
 - Alison Lawyer (2018-2020)
 - Colin King-Bailey (2018-2020)
 - Elina Rubuliak (2014-2020)
+- Jeff Van (2020-2020)
+- Josh Ling (2020-2020)
 - Karen Ivy (2020-2020)
 - Mike Ubell (2014-2020)
 - Sarah Seiter (2014-2020)

--- a/about.md
+++ b/about.md
@@ -15,11 +15,11 @@ All development on Open Disclosure happens publicly on [Github](https://github.c
 - Alison Lawyer (2018-2020)
 - Colin King-Bailey (2018-2020)
 - Elina Rubuliak (2014-2020)
+- Karen Ivy (2020-2020)
 - Mike Ubell (2014-2020)
 - Sarah Seiter (2014-2020)
 - Suzanne Doran (2016-2020)
 - Tom Dooner (2014-2020)
-- Karen Ivy (2020-2020)
 
 
 ### Open Disclosure Alumni

--- a/about.md
+++ b/about.md
@@ -12,16 +12,16 @@ All development on Open Disclosure happens publicly on [Github](https://github.c
 
 ### Current Team
 
-- Alison Lawyer (2018-2020)
-- Colin King-Bailey (2018-2020)
-- Elina Rubuliak (2014-2020)
-- Jeff Van (2020-2020)
-- Josh Ling (2020-2020)
-- Karen Ivy (2020-2020)
-- Mike Ubell (2014-2020)
-- Sarah Seiter (2014-2020)
-- Suzanne Doran (2016-2020)
-- Tom Dooner (2014-2020)
+- Alison Lawyer (since 2018)
+- Colin King-Bailey (since 2018)
+- Elina Rubuliak (since 2014)
+- Jeff Van (since 2020)
+- Josh Ling (since 2020)
+- Karen Ivy (since 2020)
+- Mike Ubell (since 2014)
+- Sarah Seiter (since 2014)
+- Suzanne Doran (since 2016)
+- Tom Dooner (since 2014)
 
 
 ### Open Disclosure Alumni


### PR DESCRIPTION
Added Karen, Jeff, and Josh to current team list and revised date formatting ("2018-2020" to "since 2018"). 