### PR TITLE
WIP: Path to locality- & date-nested contributions data in committee.html

### DIFF
--- a/_includes/candidate/finance.html
+++ b/_includes/candidate/finance.html
@@ -41,7 +41,7 @@
       {% include money-bar.html label=label value=value color="green" max=money_bar_max %}
     {% endfor %}
     {% if candidate.filer_id and candidate.filer_id != "" %}
-      <p><a href="{{ site.baseurl }}/committee/{{ candidate.filer_id }}/">{% include
+    <p><a href="{{ site.baseurl }}/committee/{{ path }}/{{ candidate.filer_id }}">{% include
         svg-icon.html icon="table-solid" %} See all contributions</a></p>
     {% endif %}
   </div>

--- a/_includes/supporting_opposing_committees.html
+++ b/_includes/supporting_opposing_committees.html
@@ -49,7 +49,7 @@ First we calculate the maximum for the money bar.
   {% if filer_id != "pending" and filer_id != "Pending" and filer_id != "PENDING" %}
   <div class="committee__support_oppose">
     <div>{{ name | smartify }}</div>
-    <a href="{{ site.baseurl }}/committee/{{ filer_id }}/">See all contributions to this committee</a>
+    <a href="{{ site.baseurl }}/committee/{{ path }}/{{ filer_id }}/">See all contributions to this committee</a>
     {% if money > 0 %}
       <div>{{ money | dollars }}</div>
       {% include money-bar.html value=money color=include.color max=max %}

--- a/_layouts/candidate.html
+++ b/_layouts/candidate.html
@@ -15,6 +15,7 @@ layout: default
 {% assign expenditures_opposing = finance.opposing_money.opposing_expenditures %}
 {% assign expenditures_supporting = finance.supporting_money.total_supporting_independent %}
 {% assign alert_text = "candidate" %}
+{% capture path %}{{ locality.slug }}/{{ election_day }}{% endcapture %}
 
 {% capture body %}
 <div class="candidate">
@@ -85,7 +86,7 @@ layout: default
     </section>
     {% if finance.total_contributions > 0 or finance.total_expenditures > 0
       or finance.supporting_money.total_supporting_independent > 0 or finance.opposing_money.opposing_expenditures > 0 %}
-      {% include candidate/finance.html candidate=candidate finance=finance %}
+      {% include candidate/finance.html candidate=candidate finance=finance path = path %}
     {% else %}
     <section class="l-section">
       <div class="l-section__content">
@@ -101,7 +102,7 @@ layout: default
       <div class="l-section__content">
         <h2 class="candidate__money-heading">Other committees controlled by this candidate</h2>
         {% for committee in other_committees %}
-        <p><a href="{{ site.baseurl }}/committee/{{ committee.filer_id }}/">{{ committee.name | smarity | escape }}</a></p>
+        <p><a href="{{ site.baseurl }}/committee/{{ path }}/{{ committee.filer_id }}/">{{ committee.name | smarity | escape }}</a></p>
         {% endfor %}
       </div>
     </section>

--- a/_layouts/committee.html
+++ b/_layouts/committee.html
@@ -3,12 +3,13 @@ layout: default
 ---
 {% assign empty_array = '' | split: '' %}
 {% assign committee = page %}
+{% capture ballot_path %}{{ committee.election }}.md{% endcapture %}
+{% assign ballot_path = ballot_path | replace: "/.md", ".md" %}
+{% assign ballot = site.elections | where: "path", ballot_path | first %}
 {% assign locality = site.localities | where: "locality_id", ballot.locality | first %}
-{% assign ballot = site.elections | where: "path", committee.election | first %}
 {% assign election_day = ballot.election | date: '%Y-%m-%d' %}
 {% assign finance = site.data.committees[locality.slug][election_day][committee.filer_id] %}
 {% assign contributions = finance.contributions | default: empty_array | sort: 'Tran_Amt1' | reverse %}
-
 
 <header class="grid">
   <h1 class="grid-col-12">{{ committee.name }}</h1>

--- a/_layouts/committee.html
+++ b/_layouts/committee.html
@@ -3,7 +3,10 @@ layout: default
 ---
 {% assign empty_array = '' | split: '' %}
 {% assign committee = page %}
-{% assign finance = site.data.committees[committee.filer_id] %}
+{% assign locality = site.localities | where: "locality_id", ballot.locality | first %}
+{% assign ballot = site.elections | where: "path", committee.election | first %}
+{% assign election_day = ballot.election | date: '%Y-%m-%d' %}
+{% assign finance = site.data.committees[locality.slug][election_day][committee.filer_id] %}
 {% assign contributions = finance.contributions | default: empty_array | sort: 'Tran_Amt1' | reverse %}
 
 

--- a/_layouts/referendum.html
+++ b/_layouts/referendum.html
@@ -11,6 +11,7 @@ layout: default
 {% assign voters_edge_url = opposing.voters_edge_url | escape %}
 {% assign locality = site.localities | where: 'locality_id', referendum.locality | first %}
 {% assign alert_text = "ballot measure" %}
+{% capture path %}{{ referendum.locality }}/{{ election_day }}{% endcapture %}
 
 
 {% capture body %}
@@ -104,7 +105,7 @@ layout: default
   </div>
   <div class="l-section__content l-section__content--half">
     <div class="subheading">In support of the measure</div>
-    {% include supporting_opposing_committees.html committees=supporting.supporting_organizations color="green" %}
+    {% include supporting_opposing_committees.html committees=supporting.supporting_organizations path=path color="green" %}
   </div>
 
 <!-- opposing contributions/expenditures column -->

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,7 +67,7 @@ gulp.task('pull:committees', function () {
 });
 
 gulp.task('pull:committees-finance', function () {
-  return gulp.src(dataDir('_data', 'committees', '*.json'))
+  return gulp.src(dataDir('_data', 'committees', '**', '*.json'))
     .pipe(gulp.dest('_data/committees'));
 });
 


### PR DESCRIPTION
**HEADS UP**: This work depends on yet-to-be-merged backend changes.

This work resolves #435.

Updates committee.html to get the contributions data for the committee at the path `_data/committees/<locality>/<election-date>/<committee-id>.json`, or in Jekyll-ish terms, `site.data.committees[locality.slug][election_day][committee.filer_id]`.

Adds Jekyll "where" queries to get locality and election date for committee from `site.localities` and `site.elections`. Is there a better way to do this, perhaps building that information right into the committee's markdown file?

:shrug: **NOTE**: The query to get election date depends on `committee.election`, which is not a key that exists on the committee markdown file, and yet it seems to be working by some mystical interdimensional force. Maybe we should understanding how this is working before this gets merged.


<!-- you may remove this section below if the PR does not include any visual changes -->
### Previews

Large screens

<!-- Please include a screenshot of the work on medium/large screens -->


Small screens

<!-- Please include a screenshot of the work on small screens -->
<!-- Hint: after upload you can change the markdown image to <img> tag with
     a `width=300` option so the image doesn't display at full width. -->
