### PR TITLE
Make November 2022 election appear as current election

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -10,7 +10,7 @@
     <h3 class="ballot-nav__section-heading">Upcoming Races</h3>
   </div>
   <section>
-    {% for nav_ballot in ballots reversed %}
+    {% for nav_ballot in ballots reversed %}{% comment %}revsersed after special election to make November election appear at top{% endcomment %}
     {% assign referendums = nav_ballot.referendums %}
     {% assign office_elections = nav_ballot.office_elections %}
     {% capture summary_path %}/election/{{ nav_ballot.locality }}/{{ nav_ballot.election }}/{% endcapture %}

--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -10,7 +10,7 @@
     <h3 class="ballot-nav__section-heading">Upcoming Races</h3>
   </div>
   <section>
-    {% for nav_ballot in ballots %}
+    {% for nav_ballot in ballots reversed %}
     {% assign referendums = nav_ballot.referendums %}
     {% assign office_elections = nav_ballot.office_elections %}
     {% capture summary_path %}/election/{{ nav_ballot.locality }}/{{ nav_ballot.election }}/{% endcapture %}

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ header: Track the money in Oakland elections
         </h4>
         <h1 class="hero__hed">{{ page.header | escape }}</h1>
         <div class="hero__btn-container">
-          <a class="btn landing__btn" href="{{ site.baseurl }}{% link _elections/oakland/2022-06-07.md %}">Follow the money</a>
+          <a class="btn landing__btn" href="{{ site.baseurl }}{% link _elections/oakland/2022-11-08.md %}">Follow the money</a>
           <h1 class="hero__hed hero__hed--centered">or</h1>
           <h4 class="hero__subheader">Search contributors by name</h4>
           <a class="btn landing__btn" href="{{ site.baseurl }}/search">Search now</a>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@ header: Track the money in Oakland elections
         </h4>
         <h1 class="hero__hed">{{ page.header | escape }}</h1>
         <div class="hero__btn-container">
+          {% comment %}Keep this date updated for latest election{% endcomment %}
           <a class="btn landing__btn" href="{{ site.baseurl }}{% link _elections/oakland/2022-11-08.md %}">Follow the money</a>
           <h1 class="hero__hed hero__hed--centered">or</h1>
           <h4 class="hero__subheader">Search contributors by name</h4>


### PR DESCRIPTION
Links to November 2022 summary page from "Follow the money" on landing page, and moves November 2022 election to the top of the ballot nav

### Previews

Large screens
<img width="600" alt="landing page showing tool-tip with updated Follow The Money link date" src="https://user-images.githubusercontent.com/20404311/187567226-e39d05a5-6654-4711-a8ca-6079a678b230.png">

<img width="600" alt="November 2022 election summary page showing ballot nav with November election at the top" src="https://user-images.githubusercontent.com/20404311/187566986-3c0a9662-d608-45a7-acb8-8d0547d38cb1.png">