### PR TITLE
feat(2023): update landing page dates for 2023 special, 2024 general

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,9 @@
 layout: default
 header: Track the money in Oakland elections
 ---
-{% assign primary_date = '2022-06-07' %}
-{% assign general_date = '2022-11-08' %}
+{% comment %}Keep these dates updated for upcoming elections{% endcomment %}
+{% assign primary_date = '2023-11-07' %}
+{% assign general_date = '2024-11-05' %}
 
 {% assign primary_totals = site.data.elections.oakland[primary_date] %}
 {% assign primary_total_funds = primary_totals.total_contributions %}
@@ -34,7 +35,7 @@ header: Track the money in Oakland elections
         <h1 class="hero__hed">{{ page.header | escape }}</h1>
         <div class="hero__btn-container">
           {% comment %}Keep this date updated for latest election{% endcomment %}
-          <a class="btn landing__btn" href="{{ site.baseurl }}{% link _elections/oakland/2022-11-08.md %}">Follow the money</a>
+          <a class="btn landing__btn" href="{{ site.baseurl }}{% link _elections/oakland/2023-11-07.md %}">Follow the money</a>
           <h1 class="hero__hed hero__hed--centered">or</h1>
           <h4 class="hero__subheader">Search contributors by name</h4>
           <a class="btn landing__btn" href="{{ site.baseurl }}/search">Search now</a>


### PR DESCRIPTION
- [x] Updates "Follow the Money" link to point to upcoming special election, 2023-11-07.
- [x] Updates `primary_date` and `general_date` variables to the dates of the upcoming special election and 2024 general election. This has the effect of updating the summary totals on the landing page.
⚠️ The `primary_date` date should be updated to March 2024 primary after the November 2023 special election if there will be any Oakland contests on the primary ballot.

<!-- you may remove this section below if the PR does not include any visual changes -->
### Previews

Large screens
<img width="600" alt="screenshot of opendisclosure.io landing page with arrow indicating updated link" src="https://github.com/caciviclab/odca-jekyll/assets/20404311/3697d16c-6169-489b-8515-2474215d6ac3">
# 👇 
<img width="600" alt="screenshot of opendisclosure.io landing page for November 2023 special election" src="https://github.com/caciviclab/odca-jekyll/assets/20404311/b10e2f47-d646-4e0e-bde3-18e885cbc8d4">
