### PR TITLE
Adhoc Fix #461 - we need something more general.

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -1,8 +1,11 @@
 {% assign locality = include.locality %}
 {% assign tabIndxVar = 4 %}
 {% assign election_year = ballot.election | slice: 0, 4 %}
+{% assign next_year = election_year | plus:1 %}
 {% assign path_end = page.url | split: "/" | last %}
 {% assign ballots = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.title contains election_year' %}
+{% assign next = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.title contains next_year' %}
+{% assign ballots = next | concat: ballots %}
 
 <nav class="ballot-nav">
   <h3 class="ballot-nav__locality-heading">{{ locality.name | escape }}</h3>


### PR DESCRIPTION
This work paritally resolves #461

This change just adds elections from the next year.  We really need something more general.

I don't understand why just doing:
`% assign ballots = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.title contains election_year or ballot.title contains next_year' %}`
generates a syntax error.