### PR TITLE
ci: pass BUNDLER_VERSION as command line option to gem install bundler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,8 @@ jobs:
       - run:
           name: Configure Bundler # use bundler version in Gemfile.lock
           command: |
-            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
-            source $BASH_ENV
-            gem install bundler
+            BUNDLER_VERSION=$(tail -1 Gemfile.lock | tr -d " ")
+            gem install bundler -v "$BUNDLER_VERSION"
       - run:
           name: Bundle Install
           command: bundle check || bundle install --path vendor/bundle


### PR DESCRIPTION
The [build started failing two days ago](https://app.circleci.com/pipelines/github/caciviclab/odca-jekyll/5237/workflows/fe54167d-5eaf-406c-b73f-80f5641d2ce4/jobs/9264) with "Error installing bundler" because it's trying to install a version of Bundler that's incompatible with Ruby 2.7. This repo's Gemfile.lock specifies Bundler 2.1.4, but CircleCI is trying to install 2.5.1.

<img width="900" alt="Screenshot of CircleCI build failing" src="https://github.com/caciviclab/odca-jekyll/assets/20404311/bf18b5d0-fccb-453e-acc5-94587bcdfa5d">


It seems detecting the desired Bundler version from an env var is no longer working. This PR changes it to pass the Bundler version, pulled from Gemfile.lock, as an explicit option to `gem install bundler` rather than relying on Gem to detect the version from the env var.