### PR TITLE
ci: update circleci legacy docker image to next-gen image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.7-node
+      - image: cimg/ruby:2.7-node
     steps:
       - checkout
       - restore_cache:
@@ -74,7 +74,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/ruby:2.7-node
+      - image: cimg/ruby:2.7-node
     environment:
       GITHUB_REPO: caciviclab/odca-jekyll
     steps:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	npm run gulp -- clean
 
 production: $(SVGS)
-	npm run dist
+	NODE_OPTIONS=$(NODE_OPTIONS) npm run dist
 	JEKYLL_ENV=production bundle exec jekyll build
 
 pull-finance:


### PR DESCRIPTION
CircleCI has been complaining that we are using their deprecated Docker image for Ruby. [In 2021 they deprecated their `circleci/...` images in favor of the "next-gen" `cimg/...` images.](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) This PR updates the docker image for both the **build** and **deploy** jobs of our CI workflow.

<img width="750" alt="Screenshot of warning about deprecated Docker images on CircleCI" src="https://github.com/caciviclab/odca-jekyll/assets/20404311/c6f5df67-42fd-4afc-b203-531312df478c">
