### PR TITLE
Link GPCs from the Contributions page

### DIFF
--- a/src/components/contributions-table.jsx
+++ b/src/components/contributions-table.jsx
@@ -17,6 +17,7 @@ class ContributionsTable extends React.Component {
       contributions: contributions.map((contribution, i) => ({
         id: i,
         name: name(contribution),
+        committee: contribution.Cmte_ID,
         type: contribution.Entity_Cd || '',
         occupation: contribution.Tran_Occ || '',
         employer: contribution.Tran_Emp || '',
@@ -213,6 +214,16 @@ class ContributionsTable extends React.Component {
 
       return <td className={classList}>{ display }</td>;
     };
+    const highlightCommittee = (contribution) => {
+      if (contribution.type === 'Committee') {
+        return (
+          <a href={`/committee/${contribution.committee}`}>
+            {contribution.name}
+          </a>
+        );
+      }
+      return contribution.name;
+    };
 
     const sortToggle = column => () => {
       const currentSort = this.state.sort;
@@ -353,7 +364,7 @@ class ContributionsTable extends React.Component {
                     </td>
                   }
                   <td className="contributors__cell contributors__name">
-                    {contribution.name}
+                    { highlightCommittee(contribution) }
                     <div className="contributors__card">
                       <div className="contributors__card-row">
                         <span className="contributors__card-type">{ contribution.type }</span>


### PR DESCRIPTION
General Purpose Committees can contribute to candidates and other committees.  This change links those contributions to the contribution page of the GPC.  This depends on backend PR 356.

![Screenshot 2024-08-09 at 2 49 11 PM](https://github.com/user-attachments/assets/ba5e2220-047f-445a-885a-c416a2e3aa61)
![Screenshot 2024-08-09 at 2 50 53 PM](https://github.com/user-attachments/assets/1ddb1198-766b-43b6-acb0-fa64f442553e)
