### PR TITLE
Change landing pages use election.display

### DIFF
--- a/_includes/ballot-nav.html
+++ b/_includes/ballot-nav.html
@@ -2,7 +2,7 @@
 {% assign tabIndxVar = 4 %}
 {% assign election_year = ballot.election | slice: 0, 4 %}
 {% assign path_end = page.url | split: "/" | last %}
-{% assign ballots = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.title contains election_year' %}
+{% assign ballots = site.elections | where: 'locality', locality.locality_id | where_exp: 'ballot', 'ballot.display >= 1' | sort: 'display'  %}
 
 <nav class="ballot-nav">
   <h3 class="ballot-nav__locality-heading">{{ locality.name | escape }}</h3>
@@ -10,7 +10,7 @@
     <h3 class="ballot-nav__section-heading">Upcoming Races</h3>
   </div>
   <section>
-    {% for nav_ballot in ballots %}{% comment %}revserse after special election to make November election appear at top{% endcomment %}
+    {% for nav_ballot in ballots %}
     {% assign referendums = nav_ballot.referendums %}
     {% assign office_elections = nav_ballot.office_elections %}
     {% capture summary_path %}/election/{{ nav_ballot.locality }}/{{ nav_ballot.election }}/{% endcapture %}

--- a/index.html
+++ b/index.html
@@ -2,9 +2,10 @@
 layout: default
 header: Track the money in Oakland elections
 ---
-{% comment %}Keep these dates updated for upcoming elections{% endcomment %}
-{% assign primary_date = '2024-03-05' %}
-{% assign general_date = '2024-11-05' %}
+{% assign general = site.elections | where: 'locality', "oakland" | where: 'display', 1 | first %}
+{% assign general_date = general.election %}
+{% assign primary = site.elections | where: 'locality', "oakland" | where: 'display', 2 | first %}
+{% assign primary_date = primary.election %}
 
 {% assign primary_totals = site.data.elections.oakland[primary_date] %}
 {% assign primary_total_funds = primary_totals.total_contributions %}
@@ -35,7 +36,7 @@ header: Track the money in Oakland elections
         <h1 class="hero__hed">{{ page.header | escape }}</h1>
         <div class="hero__btn-container">
           {% comment %}Keep this date updated for latest election{% endcomment %}
-          <a class="btn landing__btn" href="{{ site.baseurl }}{% link _elections/oakland/2024-11-05.md %}">Follow the money</a>
+          <a class="btn landing__btn" href="{{ site.baseurl }}{% link _elections/oakland/2025-04-15.md %}">Follow the money</a>
           <h1 class="hero__hed hero__hed--centered">or</h1>
           <h4 class="hero__subheader">Search contributors by name</h4>
           <a class="btn landing__btn" href="{{ site.baseurl }}/search">Search now</a>


### PR DESCRIPTION
Rather than having to update the code with each new election this change uses an added filed in the elections sheet.  The code will use display == 1 or 2 to determine the order of elections to be displayed.  
